### PR TITLE
user specified traffic split failure

### DIFF
--- a/pkg/controller/experiment/helper.go
+++ b/pkg/controller/experiment/helper.go
@@ -91,11 +91,11 @@ func overrideAssessment(instance *iter8v1alpha2.Experiment) {
 				instance.Status.Assessment.Baseline.Weight = 0
 			}
 
-			for _, candidate := range instance.Status.Assessment.Candidates {
-				if ts, ok := trafficSplit[candidate.Name]; ok {
-					candidate.Weight = ts
+			for i := range instance.Status.Assessment.Candidates {
+				if ts, ok := trafficSplit[instance.Status.Assessment.Candidates[i].Name]; ok {
+					instance.Status.Assessment.Candidates[i].Weight = ts
 				} else {
-					candidate.Weight = 0
+					instance.Status.Assessment.Candidates[i].Weight = 0
 				}
 			}
 

--- a/pkg/controller/experiment/reconcile.go
+++ b/pkg/controller/experiment/reconcile.go
@@ -59,12 +59,16 @@ func completeStatusMessage(instance *iter8v1alpha2.Experiment) string {
 		case iter8v1alpha2.OnTerminationToBaseline:
 			out += "Traffic To Baseline"
 		case iter8v1alpha2.OnTerminationKeepLast:
-			out += "Keep Last Traffic"
+			if instance.Spec.Terminate() {
+				out += "Traffic User Specified"
+			} else {
+				out += "Keep Last Traffic"
+			}
 		}
 	}
 
 	if instance.Spec.Terminate() {
-		out += "(Abort)"
+		out += " (Abort)"
 	}
 
 	return out

--- a/pkg/controller/experiment/routing/router/istio/helper.go
+++ b/pkg/controller/experiment/routing/router/istio/helper.go
@@ -291,7 +291,6 @@ func convertMatchToIstio(m *iter8v1alpha2.HTTPMatchRequest) *networkingv1alpha3.
 	return out
 }
 
-
 func toStringMatch(s *iter8v1alpha2.StringMatch) *networkingv1alpha3.StringMatch {
 	if s.Exact != nil {
 		return &networkingv1alpha3.StringMatch{


### PR DESCRIPTION
Was observing failures when attempting to terminate an experiment using `manualOverride` via: 

```bash
patch experiment reviews-v3-rollout --type='merge' -p='{"spec": {"manualOverride": { "action": "terminate", "trafficSplit": { "reviews-v2": 100, "reviews-v3": 0 }}}}'
```

Found that setting values via for loop variable did not work.

Also changes text of status message.