### PR TITLE
remove knative types, change default analytics engine, fix test case

### DIFF
--- a/install/helm/iter8-controller/templates/crds/v1alpha2/iter8.tools_experiments.yaml
+++ b/install/helm/iter8-controller/templates/crds/v1alpha2/iter8.tools_experiments.yaml
@@ -87,7 +87,7 @@ spec:
           description: ExperimentSpec defines the desired state of Experiment
           properties:
             analyticsEndpoint:
-              description: Endpoint of reaching analytics service default is http://iter8-analytics.iter8:8080
+              description: Endpoint of reaching analytics service default is http://iter8-analytics:8080
               type: string
             cleanup:
               description: Cleanup indicates whether routing rules and deployment

--- a/install/iter8-controller-telemetry-v2.yaml
+++ b/install/iter8-controller-telemetry-v2.yaml
@@ -154,7 +154,7 @@ spec:
           description: ExperimentSpec defines the desired state of Experiment
           properties:
             analyticsEndpoint:
-              description: Endpoint of reaching analytics service default is http://iter8-analytics.iter8:8080
+              description: Endpoint of reaching analytics service default is http://iter8-analytics:8080
               type: string
             cleanup:
               description: Cleanup indicates whether routing rules and deployment

--- a/install/iter8-controller.yaml
+++ b/install/iter8-controller.yaml
@@ -155,7 +155,7 @@ spec:
           description: ExperimentSpec defines the desired state of Experiment
           properties:
             analyticsEndpoint:
-              description: Endpoint of reaching analytics service default is http://iter8-analytics.iter8:8080
+              description: Endpoint of reaching analytics service default is http://iter8-analytics:8080
               type: string
             cleanup:
               description: Cleanup indicates whether routing rules and deployment

--- a/pkg/apis/iter8/v1alpha2/defaults.go
+++ b/pkg/apis/iter8/v1alpha2/defaults.go
@@ -46,7 +46,7 @@ const (
 	DefaultMaxIterations int32 = 100
 
 	// DefaultAnalyticsEndpoint is the default endpoint of analytics
-	DefaultAnalyticsEndpoint string = "http://iter8-analytics.iter8:8080"
+	DefaultAnalyticsEndpoint string = "http://iter8-analytics:8080"
 )
 
 // ServiceNamespace gets the namespace for targets

--- a/pkg/apis/iter8/v1alpha2/experiment_types.go
+++ b/pkg/apis/iter8/v1alpha2/experiment_types.go
@@ -71,7 +71,7 @@ type ExperimentSpec struct {
 	TrafficControl *TrafficControl `json:"trafficControl,omitempty"`
 
 	// Endpoint of reaching analytics service
-	// default is http://iter8-analytics.iter8:8080
+	// default is http://iter8-analytics:8080
 	// +optional
 	AnalyticsEndpoint *string `json:"analyticsEndpoint,omitempty"`
 

--- a/pkg/controller/experiment/experiment_controller.go
+++ b/pkg/controller/experiment/experiment_controller.go
@@ -268,10 +268,6 @@ type ReconcileExperiment struct {
 // +kubebuilder:rbac:groups=iter8.tools,resources=experiments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=serving.knative.dev,resources=services,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=serving.knative.dev,resources=services/status,verbs=get
-// +kubebuilder:rbac:groups=serving.knative.dev,resources=revisions,verbs=get;list;watch
-// +kubebuilder:rbac:groups=serving.knative.dev,resources=revisions/status,verbs=get
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
 func (r *ReconcileExperiment) Reconcile(request reconcile.Request) (reconcile.Result, error) {

--- a/test/data/bookinfo/abn/abn_productpage_v1v2v3.yaml
+++ b/test/data/bookinfo/abn/abn_productpage_v1v2v3.yaml
@@ -30,7 +30,7 @@ spec:
       isReward: true
   duration:
     interval: 20s
-    maxIterations: 20
+    maxIterations: 10
   trafficControl:
     strategy: progressive
     maxIncrement: 10

--- a/test/e2e/e2e-abn-scenario-1.sh
+++ b/test/e2e/e2e-abn-scenario-1.sh
@@ -3,6 +3,10 @@
 # Exit on error
 #set -e
 
+# This test case tests the following:
+#   - A/B/n experiment with three versions
+#   - one has the highest reward but fails the SLO
+
 THIS=`basename $0`
 DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1; pwd -P )"
 source "$DIR/library.sh"
@@ -11,11 +15,12 @@ YAML_PATH=$DIR/../data/bookinfo
 ISTIO_NAMESPACE="${ISTIO_NAMESPACE:-istio-system}"
 NAMESPACE="${NAMESPACE:-bookinfo-iter8}"
 IP="${IP:-127.0.0.1}"
-EXPERIMENT="${EXPERIMENT:-abn_productpage-v1v2v3}"
+EXPERIMENT="${EXPERIMENT:-abn-productpage-v1v2v3}"
 ANALYTICS_ENDPOINT="${ANALYTICS_ENDPOINT:-http://iter8-analytics:8080}"
 
-header "Iter8 e2e Test Case(s)"
+header "Scenario 3 - A/B/n test case"
 
+# Determine if mixer is disabled or not
 echo "Istio namespace: $ISTIO_NAMESPACE"
 MIXER_DISABLED=`kubectl -n $ISTIO_NAMESPACE get cm istio -o json | jq .data.mesh | grep -o 'disableMixerHttpReports: [A-Za-z]\+' | cut -d ' ' -f2`
 ISTIO_VERSION=`kubectl -n $ISTIO_NAMESPACE get pods -o yaml | grep "image:" | grep proxy | head -n 1 | awk -F: '{print $3}'`
@@ -29,16 +34,10 @@ fi
 echo "Istio version: $ISTIO_VERSION"
 echo "Istio mixer disabled: $MIXER_DISABLED"
 
-header "Scenario - A/B/n"
-
-header "Set Up"
-
-if [[ -n $ISOLATED_TEST ]]; then
-  header "Kill Existing Load Generation"
-  ps -aef | grep watch | grep -e 'curl.*bookinfo.example.com' | awk '{print $2}' | xargs kill
-fi
-
+# cleanup any existing load generation, experiments, deployments
 header "Clean Up Any Existing"
+# delete any load generation
+ps -aef | grep watch | grep -e 'curl.*bookinfo.example.com' | awk '{print $2}' | xargs kill
 # delete any existing experiment with same name
 kubectl -n $NAMESPACE delete experiments.iter8.tools $EXPERIMENT --ignore-not-found
 # delete any existing candidates
@@ -59,32 +58,27 @@ kubectl apply -f $YAML_PATH/namespace.yaml
 
 header "Create $NAMESPACE app"
 kubectl apply --namespace $NAMESPACE -f $YAML_PATH/bookinfo-tutorial.yaml
-sleep 1
-if [[ -n $ISOLATED_TEST ]]; then
-  # Travis seems slow to terminate pods so this is dangerous
-  kubectl  --namespace $NAMESPACE wait --for=condition=Ready pods --all --timeout=540s
-  if (( $? )); then echo "FAIL: application pods not started as expected"; exit 1; fi
-fi
+sleep 2
+kubectl  --namespace $NAMESPACE wait --for=condition=Ready pods --all --timeout=540s
+if (( $? )); then echo "FAIL: application pods not started as expected"; exit 1; fi
 kubectl --namespace $NAMESPACE get pods,services
 
 header "Create $NAMESPACE gateway and virtualservice"
 kubectl --namespace $NAMESPACE apply -f $YAML_PATH/bookinfo-gateway.yaml
 kubectl --namespace $NAMESPACE get gateway,virtualservice,destinationrule
 
-if [[ -n $ISOLATED_TEST ]]; then
-  header "Generate workload"
-  # We are using nodeport of the Istio ingress gateway to access bookinfo app
-  PORT=`kubectl --namespace $ISTIO_NAMESPACE get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}'`
-  # Following uses the K8s service IP/port to access bookinfo app
-  echo "Bookinfo is accessed at $IP:$PORT"
-  echo "curl -H \"Host: bookinfo.example.com\" -Is \"http://$IP:$PORT/productpage\""
-  curl -H "Host: bookinfo.example.com" -Is "http://$IP:$PORT/productpage"
-  watch -n 0.1 "curl -H \"Host: bookinfo.example.com\" -Is \"http://$IP:$PORT/productpage\"" >/dev/null 2>&1 &
-fi
+header "Generate workload"
+# We are using nodeport of the Istio ingress gateway to access bookinfo app
+PORT=`kubectl --namespace $ISTIO_NAMESPACE get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}'`
+# Following uses the K8s service IP/port to access bookinfo app
+echo "Bookinfo is accessed at $IP:$PORT"
+echo "curl -H \"Host: bookinfo.example.com\" -Is \"http://$IP:$PORT/productpage\""
+curl -H "Host: bookinfo.example.com" -Is "http://$IP:$PORT/productpage"
+watch -n 0.1 "curl -H \"Host: bookinfo.example.com\" -Is \"http://$IP:$PORT/productpage\"" >/dev/null 2>&1 &
 
 # start experiment
 # verify waiting for candidate
-header "Create Iter8 Experiment"
+header "Create A/B/n Experiment"
 yq w $YAML_PATH/abn/abn_productpage_v1v2v3.yaml metadata.name $EXPERIMENT \
   | yq w - spec.analyticsEndpoint $ANALYTICS_ENDPOINT \
   | kubectl --namespace $NAMESPACE apply -f -
@@ -112,7 +106,7 @@ kubectl --namespace $NAMESPACE get experiments.iter8.tools
 header "Test results"
 kubectl --namespace $NAMESPACE get experiments.iter8.tools $EXPERIMENT
 test_experiment_status $EXPERIMENT "ExperimentCompleted: Traffic To Winner"
-kubectl -n $NAMESPACE get virtualservice.networking.istio.io reviews.$NAMESPACE.svc.cluster.local.iter8router -o yaml | yq r - spec.http
+kubectl -n $NAMESPACE get virtualservice.networking.istio.io bookinfo -o yaml | yq r - spec.http
 test_vs_percentages bookinfo 0 0
 test_vs_percentages bookinfo 1 0
 test_vs_percentages bookinfo 2 100


### PR DESCRIPTION
- Removes knative types from generated rbac rules (issue https://github.com/iter8-tools/iter8/issues/329)
- Changes the default analytics engine URL (removes namespace) (issue https://github.com/iter8-tools/iter8/issues/328)
- fixes abn test case (still disabled) so that it works correctly when run by hand