### PR TITLE
Using deepcopy when copying ratio_statistics

### DIFF
--- a/pkg/controller/experiment/reconcile.go
+++ b/pkg/controller/experiment/reconcile.go
@@ -186,9 +186,9 @@ func (r *ReconcileExperiment) processIteration(context context.Context, instance
 		}
 
 		abort := true
-		instance.Status.Assessment.Baseline.VersionAssessment = response.BaselineAssessment
+		instance.Status.Assessment.Baseline.VersionAssessment = *response.BaselineAssessment.DeepCopy()
 		for i, ca := range response.CandidateAssessments {
-			instance.Status.Assessment.Candidates[i].VersionAssessment = ca.VersionAssessment
+			instance.Status.Assessment.Candidates[i].VersionAssessment = *ca.VersionAssessment.DeepCopy()
 			instance.Status.Assessment.Candidates[i].Rollback = ca.Rollback
 			if !ca.Rollback {
 				abort = false


### PR DESCRIPTION
when copying object with multiple level of object, using deepcopy to copy all objects.
Experiment is now showing the following data
```
 statistics:
          ratio_statistics:
            credible_interval:
              lower: 34.677673
              upper: 37.648853
            improvement_over_baseline:
              lower: 0
              upper: 0
            probability_of_beating_baseline: 0
            probability_of_being_best_version: 0
          value: 36.176277
        threshold_assessment:
          probability_of_satisfying_threshold: 1
          threshold_breached: false
```