### PR TITLE
Replace Slack link

### DIFF
--- a/mkdocs/docs/contributing.md
+++ b/mkdocs/docs/contributing.md
@@ -7,7 +7,7 @@ hide:
 # Contributing
 We are delighted that you are considering a contribution to Iter8!
 
-Please discuss the change you wish to make using [issues](https://github.com/iter8-tools/iter8/issues), [discussions](https://github.com/iter8-tools/iter8/discussions), or the [Iter8 slack workspace](https://iter8-tools.slack.com) before submitting your PR.
+Please discuss the change you wish to make using [issues](https://github.com/iter8-tools/iter8/issues), [discussions](https://github.com/iter8-tools/iter8/discussions), or the [Iter8 slack workspace](https://join.slack.com/t/iter8-tools/shared_invite/zt-awl2se8i-L0pZCpuHntpPejxzLicbmw) before submitting your PR.
 
 ## Locally building Iter8 docs
 Iter8 documentation is built using [mkdocs for material](https://squidfunk.github.io/mkdocs-material/). Follow the instructions below to build Iter8 docs locally.

--- a/mkdocs/docs/getting-started/help.md
+++ b/mkdocs/docs/getting-started/help.md
@@ -7,5 +7,5 @@ hide:
 # Getting Help
 
 1. Read [Iter8 docs](https://iter8.tools).
-2. Invite yourself to the [Iter8 slack workspace](https://iter8-tools.slack.com).
+2. Invite yourself to the [Iter8 slack workspace](https://join.slack.com/t/iter8-tools/shared_invite/zt-awl2se8i-L0pZCpuHntpPejxzLicbmw).
 3. File an issue or start a discussion on [Iter8 GitHub repo](https://github.com/iter8-tools/iter8).

--- a/mkdocs/docs/getting-started/quick-start/with-knative.md
+++ b/mkdocs/docs/getting-started/quick-start/with-knative.md
@@ -18,8 +18,8 @@ template: overrides/main.html
 
 ???+ warning "Before you begin, you will need... "
     1. **Kubernetes cluster.** You can also use [Minikube](https://minikube.sigs.k8s.io/docs/) or [Kind](https://kind.sigs.k8s.io/).
-    2. The **kubectl** CLI. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-    3. **Go 1.13+** (recommended; required for using `iter8ctl` in [Step 7](/getting-started/quick-start/with-knative/#7-observe-experiment)). Install [Go](https://golang.org/doc/install).
+    2. The `kubectl` CLI. Install `kubectl` [here](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+    3. **Go 1.13+** (recommended; required for using `iter8ctl` in [Step 7](/getting-started/quick-start/with-knative/#7-observe-experiment)). Install Go [here](https://golang.org/doc/install).
 
 ## 1. Create Kubernetes cluster
 
@@ -81,7 +81,7 @@ Knative can work with multiple networking layers. So can Iter8's Knative extensi
     ```
 
 ## 4. Create app versions
-Create baseline and candidate versions of your app. The candidate version is also referred to as the *new* or *canary* version.
+Create baseline and candidate versions of your app, `sample-app-v1` and `sample-app-v2` respectively. The candidate version is also referred to as the *new* or *canary* version.
 ```shell
 kubectl apply -f $ITER8/samples/knative/quickstart/baseline.yaml
 kubectl apply -f $ITER8/samples/knative/quickstart/experimentalservice.yaml
@@ -315,7 +315,7 @@ Observe the experiment in realtime. Paste commands from the tabs below in separa
         +--------------------------------------------+---------+-----------+
         ``` 
 
-    As the experiment progresses, you should eventually see that all of the objectives reported as being satisfied by both versions. The candidate is identified as the winner and is recommended for promotion. When the experiment completes (in ~ 2 mins), you will see the experiment stage change from `Running` to `Completed`.
+    As the experiment progresses, you should eventually see that all of the objectives reported as being satisfied by both versions. The candidate is identified as the winner and is recommended for promotion. When the experiment completes (in ~2 mins), you will see the experiment stage change from `Running` to `Completed`.
 
 === "kubectl get experiment"
 
@@ -376,7 +376,7 @@ kubectl delete -f $ITER8/samples/knative/quickstart/experimentalservice.yaml
 ```
 
 ???+ info "Understanding what happened"
-    1. You created a Knative service with two revisions, sample-app-v1 (baseline) and sample-app-v2 (candidate).
+    1. You created a Knative service with two revisions, `sample-app-v1` (baseline) and `sample-app-v2` (candidate).
     2. You generated requests for the Knative service using a Fortio job. At the start of the experiment, 100% of the requests are sent to the baseline and 0% to the candidate.
     3. You created an Iter8 experiment with canary testing and progressive deployment patterns. In each iteration, Iter8 observed the mean latency, 95th percentile tail-latency, and error-rate metrics collected by Prometheus, verified that the candidate satisfied all objectives, identified the candidate as the winner, progressively shifted traffic from the baseline to the candidate, and eventually promoted the candidate using the `kubectl apply` command embedded within its finish action.
     4. Had the candidate failed to satisfy objectives, then the baseline would have been promoted.

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -51,7 +51,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/iter8-tools/iter8
     - icon: fontawesome/brands/slack
-      link: https://iter8-tools.slack.com
+      link: https://join.slack.com/t/iter8-tools/shared_invite/zt-awl2se8i-L0pZCpuHntpPejxzLicbmw
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com/r/iter8-tools
 # Extensions

--- a/mkdocs/src/overrides/main.html
+++ b/mkdocs/src/overrides/main.html
@@ -59,7 +59,7 @@
 <!-- Announcement bar -->
 {% block announce %}
 <strong>Iter8</strong> at <a href="https://sched.co/iE2l">KubeCon + CloudNativeCon Europe 2021</a>. For more updates and support, 
-    <a href="https://iter8-tools.slack.com">
+    <a href="https://join.slack.com/t/iter8-tools/shared_invite/zt-awl2se8i-L0pZCpuHntpPejxzLicbmw">
       join <strong>Iter8</strong> workspace on <span class="twemoji">
       {% include ".icons/fontawesome/brands/slack.svg" %} </span>
       slack.


### PR DESCRIPTION
The current link is a link to login into the Iter8 workspace. It does not allow you to join the workspace. Therefore, if you are not a preexisting member of the workspace, the link is useless. We need to replace these with the invitation link.