### PR TITLE
set up  versioning

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -47,6 +47,9 @@ plugins:
 # Customization
 extra:
   title: "Cloud native release automation and experimentation"
+  extra:
+    version:
+      provider: mike  
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/iter8-tools/iter8
@@ -54,6 +57,7 @@ extra:
       link: https://join.slack.com/t/iter8-tools/shared_invite/zt-awl2se8i-L0pZCpuHntpPejxzLicbmw
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com/r/iter8-tools
+
 # Extensions
 markdown_extensions:
   - admonition

--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs-material==7.0.5
+mkdocs-material==7.1.0
 mkdocs-minify-plugin==0.4.0
 mkdocs-redirects==1.0.1


### PR DESCRIPTION
This PR addressed step 1 documented in this issue: #591 

This PR enables versioning for `Material for MkDocs` as documented here: https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/

Since we're using Material for MkDocs, the idea is to simply use the versioning method recommended and documented by this tool.