### PR TITLE
Add sample quickstart for Seldon

### DIFF
--- a/install/core/rbac/stacks/iter8-seldon/kustomization.yaml
+++ b/install/core/rbac/stacks/iter8-seldon/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- rolebindings.yaml
+- roles.yaml

--- a/install/core/rbac/stacks/iter8-seldon/rolebindings.yaml
+++ b/install/core/rbac/stacks/iter8-seldon/rolebindings.yaml
@@ -1,0 +1,31 @@
+# This cluster role binding enables Iter8 controller and handler to manipulate 
+# KFServing inference services in the cluster in any namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sdep-for-seldon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sdep-for-seldon
+subjects:
+- kind: ServiceAccount
+  name: controller
+- kind: ServiceAccount
+  name: handlers
+---
+# This role binding enables Iter8 controller and handler to manipulate 
+# Istio virtual services in the cluster in any namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vs-for-seldon
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vs-for-seldon
+subjects:
+- kind: ServiceAccount
+  name: controller
+- kind: ServiceAccount
+  name: handlers

--- a/install/core/rbac/stacks/iter8-seldon/roles.yaml
+++ b/install/core/rbac/stacks/iter8-seldon/roles.yaml
@@ -1,0 +1,31 @@
+# This cluster role enables manipulation of KFServing inferenceservices
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sdep-for-seldon
+rules:
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+---
+# This cluster role enables manipulation of Istio virtual services
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vs-for-seldon
+rules:
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - patch
+  - update

--- a/install/core/rbac/stacks/kustomization.yaml
+++ b/install/core/rbac/stacks/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 - iter8-knative
 - iter8-istio
 - iter8-kfserving
+- iter8-seldon

--- a/samples/seldon/quickstart/baseline.yaml
+++ b/samples/seldon/quickstart/baseline.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: ns-baseline
+---
+apiVersion: machinelearning.seldon.io/v1
+kind: SeldonDeployment
+metadata:
+  name: mock1
+  namespace: ns-baseline
+spec:
+  predictors:
+  - name: default
+    componentSpecs:
+    - spec:
+        containers:
+        - image: seldonio/mock_classifier:1.8.0
+          name: classifier
+    graph:
+      name: classifier
+

--- a/samples/seldon/quickstart/baseline.yaml
+++ b/samples/seldon/quickstart/baseline.yaml
@@ -6,16 +6,12 @@ metadata:
 apiVersion: machinelearning.seldon.io/v1
 kind: SeldonDeployment
 metadata:
-  name: mock1
+  name: iris
   namespace: ns-baseline
 spec:
   predictors:
   - name: default
-    componentSpecs:
-    - spec:
-        containers:
-        - image: seldonio/mock_classifier:1.8.0
-          name: classifier
     graph:
       name: classifier
-
+      modelUri: gs://seldon-models/sklearn/iris
+      implementation: SKLEARN_SERVER

--- a/samples/seldon/quickstart/candidate.yaml
+++ b/samples/seldon/quickstart/candidate.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: ns-candidate
+---
+apiVersion: machinelearning.seldon.io/v1
+kind: SeldonDeployment
+metadata:
+  name: mock2
+  namespace: ns-candidate
+spec:
+  predictors:
+  - name: default
+    componentSpecs:
+    - spec:
+        containers:
+        - image: seldonio/mock_classifier:1.8.0
+          name: classifier
+    graph:
+      name: classifier
+

--- a/samples/seldon/quickstart/candidate.yaml
+++ b/samples/seldon/quickstart/candidate.yaml
@@ -6,16 +6,13 @@ metadata:
 apiVersion: machinelearning.seldon.io/v1
 kind: SeldonDeployment
 metadata:
-  name: mock2
+  name: iris
   namespace: ns-candidate
 spec:
   predictors:
   - name: default
-    componentSpecs:
-    - spec:
-        containers:
-        - image: seldonio/mock_classifier:1.8.0
-          name: classifier
     graph:
       name: classifier
+      modelUri: gs://seldon-models/xgboost/iris
+      implementation: XGBOOST_SERVER
 

--- a/samples/seldon/quickstart/check.sh
+++ b/samples/seldon/quickstart/check.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+# dump logs from iter8 pods
+dump() {
+    # dump handler logs
+    for pod in $(kubectl -n iter8-system get po --selector=iter8/experimentName=${EXPERIMENT} -o jsonpath='{.items[*].metadata.name}'); do 
+        kubectl -n iter8-system logs $pod
+    done
+
+    # dump controller logs
+    kubectl -n iter8-system logs $(kubectl -n iter8-system get po --selector=control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+    
+    # dump analytics logs
+    kubectl -n iter8-system logs $(kubectl -n iter8-system get po --selector=app=iter8-analytics -o jsonpath='{.items[0].metadata.name}')
+}
+
+# Ensure ITER8 environment variable is set
+if [[ -z ${ITER8} ]]; then
+    echo "ITER8 environment variable needs to be set to the root folder of Iter8"
+    exit 1
+else
+    echo "ITER8 is set to " $ITER8
+fi
+
+# Check if experiment has completed
+completed="Completed"
+stage=$(kubectl get experiment $EXPERIMENT -o json | jq -r .status.stage)
+if [[ $stage = $completed ]]; then
+    echo "Experiment has Completed"
+else
+    echo "Experiment must be $completed;" 
+    echo "Experiment is $stage;"
+    exit 1
+fi
+
+
+# Check if versionRecommendedForPromotion is flowers-v2
+expectedVrfp="iris-v2"
+vrfp=$(kubectl get experiment $EXPERIMENT -o json | jq -r .status.versionRecommendedForPromotion)
+if [[ $vrfp = $expectedVrfp ]]; then
+    echo "versionRecommendedForPromotion is $vrfp"
+else
+    echo "versionRecommendedForPromotion must be $expectedVrfp; is" $vrfp
+    exit 1
+fi
+
+set +e

--- a/samples/seldon/quickstart/e2etest.sh
+++ b/samples/seldon/quickstart/e2etest.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+export EXPERIMENT=quickstart-exp
+
+# create cluster
+kind create cluster
+kubectl cluster-info --context kind-kind
+
+# platform setup
+echo "Setting up platform"
+$ITER8/samples/seldon/quickstart/platformsetup.sh
+
+echo "Create app/ML model versions"
+kubectl apply -f $ITER8/samples/seldon/quickstart/baseline.yaml
+kubectl apply -f $ITER8/samples/seldon/quickstart/candidate.yaml
+kubectl apply -f $ITER8/samples/seldon/quickstart/routing-rule.yaml
+kubectl wait --for condition=ready --timeout=600s pods --all -n ns-baseline
+kubectl wait --for condition=ready --timeout=600s pods --all -n ns-candidate
+
+echo "Generate requests"
+URL_VALUE="http://$(kubectl -n istio-system get svc istio-ingressgateway -o jsonpath='{.spec.clusterIP}'):80"
+sed "s+URL_VALUE+${URL_VALUE}+g" $ITER8/samples/seldon/quickstart/fortio.yaml | sed "s/6000s/600s/g" | kubectl apply -f -
+pod_name=$(kubectl get pods --selector=job-name=fortio-requests -o jsonpath='{.items[*].metadata.name}')
+kubectl wait --for=condition=Ready pods/"$pod_name" --timeout=240s
+pod_name=$(kubectl get pods --selector=job-name=fortio-irisv1-rewards -o jsonpath='{.items[*].metadata.name}')
+kubectl wait --for=condition=Ready pods/"$pod_name" --timeout=240s
+pod_name=$(kubectl get pods --selector=job-name=fortio-irisv2-rewards -o jsonpath='{.items[*].metadata.name}')
+kubectl wait --for=condition=Ready pods/"$pod_name" --timeout=240s
+
+echo "Define metrics"
+kubectl apply -f $ITER8/samples/seldon/quickstart/metrics.yaml
+
+echo "Launch experiment"
+kubectl apply -f $ITER8/samples/seldon/quickstart/experiment.yaml
+
+# Wait
+kubectl wait experiment $EXPERIMENT --for=condition=Completed --timeout=300s
+
+# Log final experiment
+kubectl get experiment $EXPERIMENT -o yaml
+
+# Check
+source $ITER8/samples/seldon/quickstart/check.sh
+
+kubectl delete -f $ITER8/samples/seldon/quickstart/experiment.yaml
+kubectl delete -f $ITER8/samples/seldon/quickstart/baseline.yaml
+kubectl delete -f $ITER8/samples/seldon/quickstart/candidate.yaml
+
+# delete cluster
+kind delete cluster
+
+set +e
+
+echo -e "\033[0;32mSUCCESS:\033[0m $0"

--- a/samples/seldon/quickstart/experiment.yaml
+++ b/samples/seldon/quickstart/experiment.yaml
@@ -1,0 +1,63 @@
+apiVersion: iter8.tools/v2alpha2
+kind: Experiment
+metadata:
+  name: quickstart-exp
+spec:
+  target: mock
+  strategy:
+    testingPattern: A/B
+    deploymentPattern: FixedSplit
+#    actions:
+#      # when the experiment completes, promote the winning version using kubectl apply
+#      finish:
+#      - task: common/exec
+#        with:
+#          cmd: /bin/bash
+#          args: [ "-c", "kubectl apply -f {{ .promote }}" ]
+  criteria:
+    requestCount: iter8-seldon/request-count
+    rewards: # Business rewards
+    - metric: iter8-seldon/user-engagement
+      preferredDirection: High # maximize user engagement
+    objectives:
+    - metric: iter8-seldon/mean-latency
+      upperLimit: 2000
+    - metric: iter8-seldon/95th-percentile-tail-latency
+      upperLimit: 5000
+    - metric: iter8-seldon/error-rate
+      upperLimit: "0.01"
+  duration:
+    intervalSeconds: 10
+    iterationsPerLoop: 25
+  versionInfo:
+    # information about model versions used in this experiment
+    baseline:
+      name: mock1
+      weightObjRef:
+        apiVersion: networking.istio.io/v1alpha3
+        kind: VirtualService
+        name: routing-rule
+        namespace: default
+        fieldPath: .spec.http[0].route[0].weight      
+      variables:
+      - name: ns
+        value: ns-baseline
+      - name: sid
+        value: mock1
+      - name: promote
+        value: https://raw.githubusercontent.com/iter8-tools/iter8/master/samples/kfserving/quickstart/promote-v1.yaml
+    candidates:
+    - name: mock2
+      weightObjRef:
+        apiVersion: networking.istio.io/v1alpha3
+        kind: VirtualService
+        name: routing-rule
+        namespace: default
+        fieldPath: .spec.http[0].route[1].weight      
+      variables:
+      - name: ns
+        value: ns-candidate
+      - name: sid
+        value: mock2
+      - name: promote
+        value: https://raw.githubusercontent.com/iter8-tools/iter8/master/samples/kfserving/quickstart/promote-v2.yaml

--- a/samples/seldon/quickstart/experiment.yaml
+++ b/samples/seldon/quickstart/experiment.yaml
@@ -6,7 +6,7 @@ spec:
   target: iris
   strategy:
     testingPattern: A/B
-    deploymentPattern: FixedSplit
+    deploymentPattern: Progressive
     actions:
       # when the experiment completes, promote the winning version using kubectl apply
       finish:
@@ -28,7 +28,7 @@ spec:
       upperLimit: "0.01"
   duration:
     intervalSeconds: 10
-    iterationsPerLoop: 25
+    iterationsPerLoop: 10
   versionInfo:
     # information about model versions used in this experiment
     baseline:
@@ -45,7 +45,7 @@ spec:
       - name: sid
         value: iris
       - name: promote
-        value: https://raw.githubusercontent.com/cliveseldon/iter8/master/samples/seldon/quickstart/promote-v1.yaml
+        value: https://raw.githubusercontent.com/cliveseldon/iter8/seldon/samples/seldon/quickstart/promote-v1.yaml
     candidates:
     - name: iris-v2
       weightObjRef:
@@ -60,4 +60,4 @@ spec:
       - name: sid
         value: iris
       - name: promote
-        value: https://raw.githubusercontent.com/cliveseldon/iter8/master/samples/seldon/quickstart/promote-v2.yaml
+        value: https://raw.githubusercontent.com/cliveseldon/iter8/seldon/samples/seldon/quickstart/promote-v2.yaml

--- a/samples/seldon/quickstart/experiment.yaml
+++ b/samples/seldon/quickstart/experiment.yaml
@@ -45,7 +45,7 @@ spec:
       - name: sid
         value: iris
       - name: promote
-        value: https://raw.githubusercontent.com/cliveseldon/iter8/seldon/samples/seldon/quickstart/promote-v1.yaml
+        value: https://raw.githubusercontent.com/iter8-tools/iter8/master/samples/seldon/quickstart/promote-v1.yaml
     candidates:
     - name: iris-v2
       weightObjRef:
@@ -60,4 +60,4 @@ spec:
       - name: sid
         value: iris
       - name: promote
-        value: https://raw.githubusercontent.com/cliveseldon/iter8/seldon/samples/seldon/quickstart/promote-v2.yaml
+        value: https://raw.githubusercontent.com/iter8-tools/iter8/master/samples/seldon/quickstart/promote-v2.yaml

--- a/samples/seldon/quickstart/experiment.yaml
+++ b/samples/seldon/quickstart/experiment.yaml
@@ -3,17 +3,17 @@ kind: Experiment
 metadata:
   name: quickstart-exp
 spec:
-  target: mock
+  target: iris
   strategy:
     testingPattern: A/B
     deploymentPattern: FixedSplit
-#    actions:
-#      # when the experiment completes, promote the winning version using kubectl apply
-#      finish:
-#      - task: common/exec
-#        with:
-#          cmd: /bin/bash
-#          args: [ "-c", "kubectl apply -f {{ .promote }}" ]
+    actions:
+      # when the experiment completes, promote the winning version using kubectl apply
+      finish:
+      - task: common/exec
+        with:
+          cmd: /bin/bash
+          args: [ "-c", "kubectl apply -f {{ .promote }}" ]
   criteria:
     requestCount: iter8-seldon/request-count
     rewards: # Business rewards
@@ -32,7 +32,7 @@ spec:
   versionInfo:
     # information about model versions used in this experiment
     baseline:
-      name: mock1
+      name: iris-v1
       weightObjRef:
         apiVersion: networking.istio.io/v1alpha3
         kind: VirtualService
@@ -43,11 +43,11 @@ spec:
       - name: ns
         value: ns-baseline
       - name: sid
-        value: mock1
+        value: iris
       - name: promote
-        value: https://raw.githubusercontent.com/iter8-tools/iter8/master/samples/kfserving/quickstart/promote-v1.yaml
+        value: https://raw.githubusercontent.com/cliveseldon/iter8/master/samples/seldon/quickstart/promote-v1.yaml
     candidates:
-    - name: mock2
+    - name: iris-v2
       weightObjRef:
         apiVersion: networking.istio.io/v1alpha3
         kind: VirtualService
@@ -58,6 +58,6 @@ spec:
       - name: ns
         value: ns-candidate
       - name: sid
-        value: mock2
+        value: iris
       - name: promote
-        value: https://raw.githubusercontent.com/iter8-tools/iter8/master/samples/kfserving/quickstart/promote-v2.yaml
+        value: https://raw.githubusercontent.com/cliveseldon/iter8/master/samples/seldon/quickstart/promote-v2.yaml

--- a/samples/seldon/quickstart/fortio.yaml
+++ b/samples/seldon/quickstart/fortio.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - name: fortio
         image: fortio/fortio
-        command: [ 'fortio', 'load', '-t', '6000s', '-qps', "1", '-json', '/shared/fortiooutput.json', '-H', 'Host: iris.example.com', '-H', 'Content-Type: application/json', '-payload', '{"data": {"ndarray":[[6.8,2.8,4.8,1.4]]}}',  "$(URL)" ]
+        command: [ 'fortio', 'load', '-t', '6000s', '-qps', "5", '-json', '/shared/fortiooutput.json', '-H', 'Host: iris.example.com', '-H', 'Content-Type: application/json', '-payload', '{"data": {"ndarray":[[6.8,2.8,4.8,1.4]]}}',  "$(URL)" ]
         env:
         - name: URL
           value: URL_VALUE/api/v1.0/predictions
@@ -30,7 +30,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: fortio-mock1-rewards
+  name: fortio-irisv1-rewards
 spec:
   template:
     spec:
@@ -58,7 +58,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: fortio-mock2-rewards
+  name: fortio-irisv2-rewards
 spec:
   template:
     spec:

--- a/samples/seldon/quickstart/fortio.yaml
+++ b/samples/seldon/quickstart/fortio.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fortio-requests
+spec:
+  template:
+    spec:
+      volumes:
+      - name: shared
+        emptyDir: {}    
+      containers:
+      - name: fortio
+        image: fortio/fortio
+        command: [ 'fortio', 'load', '-t', '6000s', '-qps', "1", '-json', '/shared/fortiooutput.json', '-H', 'Host: iris.example.com', '-H', 'Content-Type: application/json', '-payload', '{"data": {"ndarray":[[6.8,2.8,4.8,1.4]]}}',  "$(URL)" ]
+        env:
+        - name: URL
+          value: URL_VALUE/api/v1.0/predictions
+        volumeMounts:
+        - name: shared
+          mountPath: /shared         
+      - name: busybox
+        image: busybox:1.28
+        command: ['sh', '-c', 'echo busybox is running! && sleep 6000']          
+        volumeMounts:
+        - name: shared
+          mountPath: /shared       
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fortio-mock1-rewards
+spec:
+  template:
+    spec:
+      volumes:
+      - name: shared
+        emptyDir: {}    
+      containers:
+      - name: fortio
+        image: fortio/fortio
+        command: [ 'fortio', 'load', '-t', '6000s', '-qps', "0.7", '-json', '/shared/fortiooutput.json', '-H', 'Content-Type: application/json', '-payload', '{"reward": 1}',  "$(URL)" ]
+        env:
+        - name: URL
+          value: URL_VALUE/seldon/ns-baseline/iris/api/v1.0/feedback
+        volumeMounts:
+        - name: shared
+          mountPath: /shared         
+      - name: busybox
+        image: busybox:1.28
+        command: ['sh', '-c', 'echo busybox is running! && sleep 6000']          
+        volumeMounts:
+        - name: shared
+          mountPath: /shared       
+      restartPolicy: Never
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fortio-mock2-rewards
+spec:
+  template:
+    spec:
+      volumes:
+      - name: shared
+        emptyDir: {}    
+      containers:
+      - name: fortio
+        image: fortio/fortio
+        command: [ 'fortio', 'load', '-t', '6000s', '-qps', "1", '-json', '/shared/fortiooutput.json', '-H', 'Content-Type: application/json', '-payload', '{"reward": 1}',  "$(URL)" ]
+        env:
+        - name: URL
+          value: URL_VALUE/seldon/ns-candidate/iris/api/v1.0/feedback
+        volumeMounts:
+        - name: shared
+          mountPath: /shared         
+      - name: busybox
+        image: busybox:1.28
+        command: ['sh', '-c', 'echo busybox is running! && sleep 6000']          
+        volumeMounts:
+        - name: shared
+          mountPath: /shared       
+      restartPolicy: Never

--- a/samples/seldon/quickstart/generate-traffic.sh
+++ b/samples/seldon/quickstart/generate-traffic.sh
@@ -5,16 +5,16 @@ send_reward () {
     if [ $R -gt 6 ]
     then
 	echo "Sending reward to baseline!"
-	curl -d '{"reward": 1}'    -X POST http://172.18.255.1/seldon/ns-baseline/mock1/api/v1.0/feedback    -H "Content-Type: application/json"
+	curl -d '{"reward": 1}'    -X POST http://172.18.255.1/seldon/ns-baseline/iris/api/v1.0/feedback    -H "Content-Type: application/json"
     else
 	echo "Sending reward to candidate!"
-	curl -d '{"reward": 1}'    -X POST http://172.18.255.1/seldon/ns-candidate/mock2/api/v1.0/feedback    -H "Content-Type: application/json"
+	curl -d '{"reward": 1}'    -X POST http://172.18.255.1/seldon/ns-candidate/iris/api/v1.0/feedback    -H "Content-Type: application/json"
     fi    
 }
 
 # Send a request to A/B test
 send_request () {
-   curl -d '{"data": {"ndarray":[[1.0, 2.0, 5.0]]}}'    -X POST http://172.18.255.1/api/v1.0/predictions    -H "Content-Type: application/json" -HHost:example.com    
+   curl -d '{"data": {"ndarray":[[6.8,2.8,4.8,1.4]]}}'    -X POST http://172.18.255.1/api/v1.0/predictions    -H "Content-Type: application/json" -HHost:iris.example.com    
 }
 
 i=0

--- a/samples/seldon/quickstart/generate-traffic.sh
+++ b/samples/seldon/quickstart/generate-traffic.sh
@@ -1,0 +1,28 @@
+
+# Send a random reward to baseline or candidate
+send_reward () {
+    R=$((1 + $RANDOM % 10))
+    if [ $R -gt 6 ]
+    then
+	echo "Sending reward to baseline!"
+	curl -d '{"reward": 1}'    -X POST http://172.18.255.1/seldon/ns-baseline/mock1/api/v1.0/feedback    -H "Content-Type: application/json"
+    else
+	echo "Sending reward to candidate!"
+	curl -d '{"reward": 1}'    -X POST http://172.18.255.1/seldon/ns-candidate/mock2/api/v1.0/feedback    -H "Content-Type: application/json"
+    fi    
+}
+
+# Send a request to A/B test
+send_request () {
+   curl -d '{"data": {"ndarray":[[1.0, 2.0, 5.0]]}}'    -X POST http://172.18.255.1/api/v1.0/predictions    -H "Content-Type: application/json" -HHost:example.com    
+}
+
+i=0
+while true; do
+    let i=i+1
+    if ! ((i % 4)); then
+	send_reward
+    fi
+    send_request
+    sleep 0.2
+done

--- a/samples/seldon/quickstart/istio-gateway.yaml
+++ b/samples/seldon/quickstart/istio-gateway.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: seldon-gateway
+  namespace: istio-system
+spec:
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+

--- a/samples/seldon/quickstart/metrics.yaml
+++ b/samples/seldon/quickstart/metrics.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: iter8-seldon
+---
+apiVersion: iter8.tools/v2alpha2
+kind: Metric
+metadata:
+  name: 95th-percentile-tail-latency
+  namespace: iter8-seldon
+spec:
+  description: 95th percentile tail latency
+  jqExpression: .data.result[0].value[1] | tonumber
+  params:
+  - name: query
+    value: |
+      histogram_quantile(0.95, sum(rate(seldon_api_executor_client_requests_seconds_bucket{seldon_deployment_id='$sid',kubernetes_namespace='$ns'}[${elapsedTime}s])) by (le))
+  provider: prometheus
+  sampleSize: iter8-seldon/request-count
+  type: Gauge
+  units: milliseconds
+  urlTemplate: http://seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query
+---
+apiVersion: iter8.tools/v2alpha2
+kind: Metric
+metadata:
+  name: error-count
+  namespace: iter8-seldon
+spec:
+  description: Number of error responses
+  jqExpression: .data.result[0].value[1] | tonumber
+  params:
+  - name: query
+    value: |
+      sum(increase(seldon_api_executor_server_requests_seconds_count{code!='200',seldon_deployment_id='$sid',kubernetes_namespace='$ns'}[${elapsedTime}s])) or on() vector(0)
+  provider: prometheus
+  type: Counter
+  urlTemplate: http://seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query  
+---
+apiVersion: iter8.tools/v2alpha2
+kind: Metric
+metadata:
+  name: error-rate
+  namespace: iter8-seldon
+spec:
+  description: Fraction of requests with error responses
+  jqExpression: .data.result[0].value[1] | tonumber
+  params:
+  - name: query
+    value: |
+      (sum(increase(seldon_api_executor_server_requests_seconds_count{code!='200',seldon_deployment_id='$sid',kubernetes_namespace='$ns'}[${elapsedTime}s])) or on() vector(0)) / (sum(increase(seldon_api_executor_server_requests_seconds_count{seldon_deployment_id='$sid',kubernetes_namespace='$ns'}[${elapsedTime}s])) or on() vector(0))
+  provider: prometheus
+  sampleSize: iter8-seldon/request-count
+  type: Gauge
+  urlTemplate: http://seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query    
+---
+apiVersion: iter8.tools/v2alpha2
+kind: Metric
+metadata:
+  name: mean-latency
+  namespace: iter8-seldon
+spec:
+  description: Mean latency
+  jqExpression: .data.result[0].value[1] | tonumber
+  params:
+  - name: query
+    value: |
+      (sum(increase(seldon_api_executor_client_requests_seconds_sum{seldon_deployment_id='$sid',kubernetes_namespace='$ns'}[${elapsedTime}s])) or on() vector(0)) / (sum(increase(seldon_api_executor_client_requests_seconds_count{seldon_deployment_id='$sid',kubernetes_namespace='$ns'}[${elapsedTime}s])) or on() vector(0))
+  provider: prometheus
+  sampleSize: iter8-seldon/request-count
+  type: Gauge
+  units: milliseconds
+  urlTemplate: http://seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query      
+---
+apiVersion: iter8.tools/v2alpha2
+kind: Metric
+metadata:
+  name: request-count
+  namespace: iter8-seldon
+spec:
+  description: Number of requests
+  jqExpression: .data.result[0].value[1] | tonumber
+  params:
+  - name: query
+    value: |
+      sum(increase(seldon_api_executor_client_requests_seconds_sum{seldon_deployment_id='$sid',kubernetes_namespace='$ns'}[${elapsedTime}s])) or on() vector(0)
+  provider: prometheus
+  type: Counter
+  urlTemplate: http://seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query
+---
+apiVersion: iter8.tools/v2alpha2
+kind: Metric
+metadata:
+  name: user-engagement
+  namespace: iter8-seldon
+spec:
+  description: Number of feedback requests
+  jqExpression: .data.result[0].value[1] | tonumber
+  params:
+  - name: query
+    value: |
+      sum(increase(seldon_api_executor_server_requests_seconds_count{service='feedback',seldon_deployment_id='$sid',kubernetes_namespace='$ns'}[${elapsedTime}s])) or on() vector(0)
+  provider: prometheus
+  type: Gauge
+  urlTemplate: http://seldon-core-analytics-prometheus-seldon.seldon-system/api/v1/query

--- a/samples/seldon/quickstart/platformsetup.sh
+++ b/samples/seldon/quickstart/platformsetup.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -e 
+
+# Step 0: Ensure environment and arguments are well-defined
+
+## 0(a). Ensure ITER8 environment variable is set
+if [[ -z ${ITER8} ]]; then
+    echo "ITER8 environment variable needs to be set to the root folder of Iter8"
+    exit 1
+else
+    echo "ITER8 is set to " $ITER8
+fi
+
+## 0(b). Ensure Kubernetes cluster is available
+KUBERNETES_STATUS=$(kubectl version | awk '/^Server Version:/' -)
+if [[ -z ${KUBERNETES_STATUS} ]]; then
+    echo "Kubernetes cluster is unavailable"
+    exit 1
+else
+    echo "Kubernetes cluster is available"
+fi
+
+## 0(c). Ensure Kustomize v3 or v4 is available
+KUSTOMIZE_VERSION=$(kustomize  version | cut -d. -f1 | tail -c 2)
+if [[ ${KUSTOMIZE_VERSION} -ge "3" ]]; then
+    echo "Kustomize v3+ available"
+else
+    echo "Kustomize v3+ is unavailable"
+    exit 1
+fi
+
+## 0(d). Ensure Helm is available
+KUSTOMIZE_VERSION=$(helm  version | cut -d. -f2 | tail -c 2)
+if [[ ${KUSTOMIZE_VERSION} -ge "3" ]]; then
+    echo "Helm v3+ available"
+else
+    echo "Helm v3+ is unavailable"
+    exit 1
+fi
+
+# Step 1: Export correct tags for install artifacts
+export ISTIO_VERSION="${ISTIO_VERSION:-1.9.4}"
+echo "ISTIO_VERSION=$ISTIO_VERSION"
+
+# Step 2: Install Istio (https://istio.io/latest/docs/setup/getting-started/)
+echo "Installing Istio"
+WORK_DIR=$(pwd)
+TEMP_DIR=$(mktemp -d)
+cd $TEMP_DIR
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
+cd istio-${ISTIO_VERSION}
+export PATH=$PWD/bin:$PATH
+cd $WORK_DIR
+istioctl install -y -f ${ITER8}/samples/istio/quickstart/istio-minimal-operator.yaml
+echo "Istio installed successfully"
+
+# Step 3: Ensure readiness of Istio pods
+echo "Waiting for all Istio pods to be running..."
+kubectl wait --for condition=ready --timeout=300s pods --all -n istio-system
+
+# Step 4: Install Seldon
+echo "Installing Seldon"
+kubectl create ns seldon-system || echo "seldon-system Namespace exists"
+helm upgrade --install --wait seldon-core seldon-core-operator --repo https://storage.googleapis.com/seldon-charts --set usageMetrics.enabled=true --namespace seldon-system --set istio.enabled=true
+kubectl apply -f ${ITER8}/samples/seldon/quickstart/istio-gateway.yaml
+
+# Step 5: Install Seldon Analytics
+echo "Installing Seldon Analytics"
+helm upgrade --install --wait seldon-core-analytics seldon-core-analytics --repo https://storage.googleapis.com/seldon-charts --namespace seldon-system
+
+### Note: the preceding steps perform domain install; following steps perform Iter8 install
+
+# Step 6: Install Iter8
+echo "Installing Iter8 with Seldon Support"
+kustomize build $ITER8/install/core | kubectl apply -f -
+
+# Step 7: Verify Iter8 installation
+echo "Verifying Iter8 and add-on installation"
+kubectl wait --for condition=ready --timeout=300s pods --all -n iter8-system
+

--- a/samples/seldon/quickstart/promote-v1.yaml
+++ b/samples/seldon/quickstart/promote-v1.yaml
@@ -18,13 +18,4 @@ spec:
         response:
           set:
             version: iris-v1
-      weight: 50
-    - destination:
-        host: iris-default.ns-candidate.svc.cluster.local
-        port:
-          number: 8000
-      headers:
-        response:
-          set:
-            version: iris-v2
-      weight: 50
+      weight: 100

--- a/samples/seldon/quickstart/promote-v2.yaml
+++ b/samples/seldon/quickstart/promote-v2.yaml
@@ -1,3 +1,16 @@
+apiVersion: machinelearning.seldon.io/v1
+kind: SeldonDeployment
+metadata:
+  name: iris
+  namespace: ns-baseline
+spec:
+  predictors:
+  - name: default
+    graph:
+      name: classifier
+      modelUri: gs://seldon-models/xgboost/iris
+      implementation: XGBOOST_SERVER
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -17,14 +30,5 @@ spec:
       headers:
         response:
           set:
-            version: iris-v1
-      weight: 50
-    - destination:
-        host: iris-default.ns-candidate.svc.cluster.local
-        port:
-          number: 8000
-      headers:
-        response:
-          set:
             version: iris-v2
-      weight: 50
+      weight: 100

--- a/samples/seldon/quickstart/routing-rule.yaml
+++ b/samples/seldon/quickstart/routing-rule.yaml
@@ -18,7 +18,7 @@ spec:
         response:
           set:
             version: iris-v1
-      weight: 50
+      weight: 100
     - destination:
         host: iris-default.ns-candidate.svc.cluster.local
         port:
@@ -27,4 +27,4 @@ spec:
         response:
           set:
             version: iris-v2
-      weight: 50
+      weight: 0

--- a/samples/seldon/quickstart/routing-rule.yaml
+++ b/samples/seldon/quickstart/routing-rule.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: routing-rule
+  namespace: default
+spec:
+  gateways:
+  - istio-system/seldon-gateway
+  hosts:
+  - example.com
+  http:
+  - route:
+    - destination:
+        host: mock1-default.ns-baseline.svc.cluster.local
+        port:
+          number: 8000
+      headers:
+        request:
+          set:
+            Host: mock1-default
+        response:
+          set:
+            version: mock-v1
+      weight: 50
+    - destination:
+        host: mock2-default.ns-candidate.svc.cluster.local
+        port:
+          number: 8000
+      headers:
+        request:
+          set:
+            Host: mock2-default
+        response:
+          set:
+            version: mock-v2
+      weight: 50


### PR DESCRIPTION
Adds an initial Seldon quickstart using 2 Iris models.

Notes

 * The URLs for promotion in the experiment are set to what they would be when this PR is merged. So if tested would need changing to my branch to work.
 * The platformsetup.sh needs Helm

If merged I can create docs in a lter PR to update quickstart.