### PR TITLE
do not change deployment label

### DIFF
--- a/samples/istio/gitops/runCI.sh
+++ b/samples/istio/gitops/runCI.sh
@@ -10,7 +10,5 @@ sed "s|name: gitops-exp|name: gitops-exp-$RANDOM|" templates/experiment.yaml > .
 # use a random color for a new experiment candidate
 declare -a colors=("red" "orange" "blue" "green" "yellow" "violet" "brown")
 color=`expr $RANDOM % ${#colors[@]}`
-version=`git rev-parse --short HEAD`
-sed "s|value: COLOR|value: \"${colors[$color]}\"|" templates/productpage-candidate.yaml |\
-sed "s|version: v.*|version: v$version|" > ./productpage-candidate.yaml
+sed "s|value: COLOR|value: \"${colors[$color]}\"|" templates/productpage-candidate.yaml > ./productpage-candidate.yaml
 


### PR DESCRIPTION
Deployment label is an immutable field. Changing it across versions will result in ArgoCD failing to sync due to it calling `kubectl apply` or `kubectl replace`, for which immutable fields cannot be updated.