### PR TITLE
fix gitops path that was changed

### DIFF
--- a/samples/istio/gitops/argocd-app.yaml
+++ b/samples/istio/gitops/argocd-app.yaml
@@ -15,7 +15,7 @@ spec:
     kind: VirtualService
   project: default
   source:
-    path: samples/gitops
+    path: samples/istio/gitops
     repoURL: https://github.com/MY_ORG/iter8
     targetRevision: master
   syncPolicy:

--- a/samples/istio/gitops/templates/experiment.yaml
+++ b/samples/istio/gitops/templates/experiment.yaml
@@ -26,7 +26,7 @@ spec:
                   git config --global user.email 'iter8@iter8.tools';\
                   git config --global user.name 'Iter8';\
                   git clone https://${USER}:${TOKEN}@${REPO} --branch=${BRANCH};\
-                  cd iter8/samples/gitops;\
+                  cd iter8/samples/istio/gitops;\
                   TMP=`mktemp`;\
                   sed 's/candidate/stable/g' {{ .filepath }} > $TMP;\
                   mv $TMP productpage.yaml;\


### PR DESCRIPTION
@sriumcp it looks like you moved gitops stuff from `samples/gitops` to `samples/istio/gitops`. That broke some links in the resource files. This PR fixes the broken links.