### PR TITLE
Update instructions to install iter8ctl to version 1.1.6

### DIFF
--- a/mkdocs/docs/getting-started/install.md
+++ b/mkdocs/docs/getting-started/install.md
@@ -19,7 +19,7 @@ kubectl wait --for=condition=Ready pods --all -n iter8-system
 ## Install `iter8ctl`
 Install `iter8ctl` CLI on your local machine as follows. This step requires [Go 1.16+](https://golang.org/doc/install).
 ```shell
-GO111MODULE=on GOBIN=/usr/local/bin go get github.com/iter8-tools/iter8ctl@v0.1.5
+GO111MODULE=on GOBIN=/usr/local/bin go get github.com/iter8-tools/iter8ctl@v0.1.6
 ```
 
 <!-- ## Pinning the Iter8 version


### PR DESCRIPTION
Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>

Change to iter8ctl enables use with IKS