### PR TITLE
feat(chaos): Adding litmus chaos helm template

### DIFF
--- a/samples/chaos/charts/Chart.yaml
+++ b/samples/chaos/charts/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+appVersion: "1.13.8"
+description: A Helm chart to install litmus infra components on Kubernetes
+name: litmus
+version: 1.16.0
+home: https://litmuschaos.io
+sources:
+  - https://github.com/litmuschaos/litmus
+keywords:
+  - chaos-engineering
+  - resiliency
+  - kubernetes
+maintainers:
+  - name: ksatchit
+    email: karthik.s@mayadata.io
+  - name: ispeakc0de
+    email: shubham@chaosnative.com
+icon: https://raw.githubusercontent.com/litmuschaos/icons/master/litmus.png

--- a/samples/chaos/charts/README.md
+++ b/samples/chaos/charts/README.md
@@ -1,0 +1,53 @@
+# litmus
+
+![Version: 1.16.0](https://img.shields.io/badge/Version-1.16.0-informational?style=flat-square) ![AppVersion: 1.13.8](https://img.shields.io/badge/AppVersion-1.13.8-informational?style=flat-square)
+
+A Helm chart to install litmus infra components on Kubernetes
+
+**Homepage:** <https://litmuschaos.io>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| ksatchit | karthik.s@mayadata.io |  |
+| ispeakc0de | shubham@chaosnative.com |  |
+
+## Source Code
+
+* <https://github.com/litmuschaos/litmus>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| appinfo.appkind | string | `nil` |  |
+| appinfo.applabel | string | `nil` |  |
+| appinfo.appns | string | `nil` |  |
+| customLabels | object | `{}` | Additional labels |
+| experiments.disabled | list | `[]` |  |
+| fullnameOverride | string | `"litmus"` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts | list | `[{"host":null,"paths":[]}]` |  kubernetes.io/tls-acme: "true" |
+| ingress.tls | list | `[]` |  |
+| litmusGO.image.pullPolicy | string | `"Always"` |  |
+| litmusGO.image.repository | string | `"litmuschaos/go-runner"` |  |
+| litmusGO.image.tag | string | `"1.13.8"` |  |
+| nameOverride | string | `"litmus"` |  |
+| nodeSelector | object | `{}` |  |
+| operator.image.pullPolicy | string | `"Always"` |  |
+| operator.image.repository | string | `"litmuschaos/chaos-operator"` |  |
+| operator.image.tag | string | `"1.13.8"` |  |
+| operatorMode | string | `"standard"` |  |
+| operatorName | string | `"chaos-operator"` |  |
+| policies | object | `{"monitoring":{"disabled":false}}` |  https://docs.litmuschaos.io/docs/faq-general/#does-litmus-track-any-usage-metrics-on-the-test-clusters |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| runner.image.repository | string | `"litmuschaos/chaos-runner"` |  |
+| runner.image.tag | string | `"1.13.8"` |  |
+| service.port | int | `80` |  |
+| service.type | string | `"ClusterIP"` |  |
+| tolerations | list | `[]` |  |
+

--- a/samples/chaos/charts/crds/chaosengine_crd.yaml
+++ b/samples/chaos/charts/crds/chaosengine_crd.yaml
@@ -1,0 +1,456 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: chaosengines.litmuschaos.io
+spec:
+  group: litmuschaos.io
+  names:
+    kind: ChaosEngine
+    listKind: ChaosEngineList
+    plural: chaosengines
+    singular: chaosengine
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+            properties:
+              jobCleanUpPolicy:
+                type: string
+                pattern: ^(delete|retain)$
+                # alternate ways to do this in case of complex pattern matches
+                #oneOf:
+                #  - pattern: '^delete$'
+                #  - pattern: '^retain$'
+              annotationCheck:
+                type: string
+                pattern: ^(true|false)$
+              appinfo:
+                type: object
+                properties:
+                  appkind:
+                    type: string
+                    pattern: ^(^$|deployment|statefulset|daemonset|deploymentconfig|rollout)$
+                  applabel:
+                    type: string
+                  appns:
+                    type: string
+              auxiliaryAppInfo:
+                type: string
+              engineState:
+                type: string
+                pattern: ^(active|stop)$
+              chaosServiceAccount:
+                type: string
+              terminationGracePeriodSeconds:
+                type: integer
+              components:
+                type: object
+                properties:
+                  runner:
+                    x-kubernetes-preserve-unknown-fields: true 
+                    type: object
+                    properties:
+                      image:
+                        type: string
+                      type:
+                        type: string
+                        pattern: ^(go)$
+                      runnerAnnotations:
+                        type: object
+                        additionalProperties:
+                          type: string
+                          properties:
+                            key:
+                              type: string
+                              minLength: 1
+                            value:
+                              type: string
+                              minLength: 1
+                      tolerations:
+                        description: Pod's tolerations.
+                        items:
+                          description: The pod with this Toleration tolerates any taint matches the <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect to match. Empty means all effects.
+                              type: string
+                            key:
+                              description: Taint key the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists.
+                              type: string
+                            operator:
+                              description: Operators are Exists or Equal. Defaults to Equal.
+                              type: string
+                            tolerationSeconds:
+                              description: Period of time the toleration tolerates the taint.
+                              format: int64
+                              type: integer
+                            value:
+                              description: If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+              experiments:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    spec:
+                      type: object
+                      properties:
+                        probe:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                              - runProperties
+                            properties:
+                              name:
+                                type: string
+                              type:
+                                type: string
+                                minLength: 1
+                                pattern: ^(k8sProbe|httpProbe|cmdProbe|promProbe)$
+                              k8sProbe/inputs:
+                                type: object
+                                properties:
+                                  group:
+                                    type: string
+                                  version:
+                                    type: string
+                                  resource:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                  fieldSelector:
+                                    type: string
+                                  labelSelector:
+                                    type: string
+                                  operation:
+                                    type: string
+                                    pattern: ^(present|absent|create|delete)$
+                                    minLength: 1
+                              cmdProbe/inputs:
+                                type: object
+                                properties:
+                                  command:
+                                    type: string
+                                    minLength: 1
+                                  comparator:
+                                    type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        minLength: 1
+                                        pattern: ^(int|float|string)$
+                                      criteria:
+                                        type: string
+                                      value:
+                                        type: string
+                                  source:
+                                    type: string
+                                    minLength: 1
+                              httpProbe/inputs:
+                                type: object
+                                properties:
+                                  url:
+                                    type: string
+                                    minLength: 1
+                                  insecureSkipVerify:
+                                    type: boolean
+                                  responseTimeout: 
+                                    type: integer
+                                  method:
+                                    type: object
+                                    minProperties: 1
+                                    properties:
+                                      get:
+                                        type: object
+                                        properties:
+                                          criteria:
+                                            type: string
+                                            minLength: 1
+                                          responseCode:
+                                            type: string
+                                            minLength: 1
+                                      post:
+                                        type: object
+                                        properties:
+                                          contentType:
+                                            type: string
+                                            minLength: 1
+                                          body:
+                                            type: string
+                                          bodyPath: 
+                                            type: string
+                                          criteria:
+                                            type: string
+                                            minLength: 1
+                                          responseCode:
+                                            type: string
+                                            minLength: 1                                       
+                              promProbe/inputs:
+                                type: object
+                                properties:
+                                  endpoint:
+                                    type: string
+                                  query:
+                                    type: string
+                                  queryPath:
+                                    type: string
+                                  comparator:
+                                    type: object
+                                    properties:
+                                      criteria:
+                                        type: string
+                                      value:
+                                        type: string
+                              runProperties:
+                                type: object
+                                minProperties: 3
+                                required:
+                                  - probeTimeout
+                                  - interval
+                                  - retry
+                                properties:
+                                  probeTimeout:
+                                    type: integer
+                                  interval:
+                                    type: integer
+                                  retry: 
+                                    type: integer
+                                  probePollingInterval:
+                                    type: integer
+                                  initialDelaySeconds:
+                                    type: integer
+                                  stopOnFailure:
+                                    type: boolean
+                              mode:
+                                type: string
+                                pattern: ^(SOT|EOT|Edge|Continuous|OnChaos)$
+                                minLength: 1
+                              data:
+                                type: string
+                        components:
+                          x-kubernetes-preserve-unknown-fields: true 
+                          type: object
+                          properties:
+                            statusCheckTimeouts:
+                              type: object
+                              properties:
+                                delay:
+                                  type: integer
+                                timeout:
+                                  type: integer
+                            nodeSelector:
+                              type: object
+                              additionalProperties:
+                                type: string
+                                properties:
+                                  key:
+                                    type: string
+                                    minLength: 1
+                                    allowEmptyValue: false
+                                  value:
+                                    type: string
+                                    minLength: 1
+                                    allowEmptyValue: false
+                            experimentImage:
+                              type: string
+                            env:
+                              type: array
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                            configMaps:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  mountPath:
+                                    type: string
+                            secrets:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  mountPath:
+                                    type: string
+                            experimentAnnotations:
+                              type: object
+                              additionalProperties:
+                                type: string
+                                properties:
+                                  key:
+                                    type: string
+                                    minLength: 1
+                                    allowEmptyValue: false
+                                  value:
+                                    type: string
+                                    minLength: 1
+                                    allowEmptyValue: false
+                            tolerations:
+                              description: Pod's tolerations.
+                              items:
+                                description: The pod with this Toleration tolerates any taint matches the <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: Effect to match. Empty means all effects.
+                                    type: string
+                                  key:
+                                    description: Taint key the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists.
+                                    type: string
+                                  operator:
+                                    description: Operators are Exists or Equal. Defaults to Equal.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: Period of time the toleration tolerates the taint.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+    served: true
+    storage: true
+    subresources: {}  
+  conversion:
+    strategy: None

--- a/samples/chaos/charts/crds/chaosexperiment_crd.yaml
+++ b/samples/chaos/charts/crds/chaosexperiment_crd.yaml
@@ -1,0 +1,159 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: chaosexperiments.litmuschaos.io
+spec:
+  group: litmuschaos.io
+  names:
+    kind: ChaosExperiment
+    listKind: ChaosExperimentList
+    plural: chaosexperiments
+    singular: chaosexperiment
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          description: 
+            type: object
+            additionalProperties:
+              type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object            
+          spec:
+            type: object
+            properties:
+              definition:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object
+                properties:
+                  args:
+                    type: array
+                    items:
+                      type: string
+                  command:
+                    type: array
+                    items:
+                      type: string
+                  env:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    type: string
+                  labels:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  scope:
+                    type: string
+                    pattern: ^(Namespaced|Cluster)$
+                  permissions:
+                    type: array
+                    items:
+                      type: object
+                      minProperties: 3
+                      required:
+                        - apiGroups
+                        - resources
+                        - verbs
+                      properties:
+                        apiGroups:
+                          type: array
+                          items:
+                            type: string
+                        resources:
+                          type: array
+                          items:
+                            type: string
+                        verbs:
+                          type: array
+                          items:
+                            type: string
+                        resourceNames:
+                          type: array
+                          items:
+                            type: string
+                        nonResourceURLs:
+                          type: array
+                          items:
+                            type: string
+                  configMaps:
+                    type: array
+                    items:
+                      type: object
+                      minProperties: 2
+                      properties:
+                        name:
+                          type: string
+                          allowEmptyValue: false
+                          minLength: 1
+                        mountPath:
+                          type: string
+                          allowEmptyValue: false
+                          minLength: 1
+                  secrets:
+                    type: array
+                    items:
+                      type: object
+                      minProperties: 2
+                      properties:
+                        name:
+                          type: string
+                          allowEmptyValue: false
+                          minLength: 1
+                        mountPath:
+                          type: string
+                          allowEmptyValue: false
+                          minLength: 1
+                  hostFileVolumes:
+                    type: array
+                    items:
+                      type: object
+                      minProperties: 3
+                      properties:
+                        name:
+                          type: string
+                          allowEmptyValue: false
+                          minLength: 1
+                        mountPath:
+                          type: string
+                          allowEmptyValue: false
+                          minLength: 1
+                        nodePath:
+                          type: string
+                          allowEmptyValue: false
+                          minLength: 1
+                  securityContext:
+                    x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  hostPID:
+                    type: boolean
+
+    served: true
+    storage: true
+    subresources: {}
+  conversion:
+    strategy: None

--- a/samples/chaos/charts/crds/chaosresult_crd.yaml
+++ b/samples/chaos/charts/crds/chaosresult_crd.yaml
@@ -1,0 +1,41 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: chaosresults.litmuschaos.io
+spec:
+  group: litmuschaos.io
+  names:
+    kind: ChaosResult
+    listKind: ChaosResultList
+    plural: chaosresults
+    singular: chaosresult
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+    served: true
+    storage: true
+    subresources: {}
+  conversion:
+    strategy: None

--- a/samples/chaos/charts/templates/NOTES.txt
+++ b/samples/chaos/charts/templates/NOTES.txt
@@ -1,0 +1,21 @@
+## Additional Steps (Verification)
+----------------------------------
+You can run the following commands if you wish to verify if all desired components are installed successfully.
+
+- Check if chaos api-resources are available: 
+
+root@demo:~# kubectl api-resources | grep litmus 
+chaosengines                                   litmuschaos.io                 true         ChaosEngine
+chaosexperiments                               litmuschaos.io                 true         ChaosExperiment
+chaosresults                                   litmuschaos.io                 true         ChaosResult
+
+- Check if the litmus chaos operator deployment is running successfully
+
+root@demo:~# kubectl get pods -n litmus 
+NAME                      READY   STATUS    RESTARTS   AGE
+litmus-7d998b6568-nnlcd   1/1     Running   0          106s
+
+## Start Running Chaos Experiments 
+----------------------------------
+With this, you are good to go!! Refer to the chaos experiment documentation @ https://docs.litmuschaos.io 
+to start executing your first experiment.

--- a/samples/chaos/charts/templates/_helpers.tpl
+++ b/samples/chaos/charts/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "litmus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "litmus.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "litmus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "litmus.labels" }}
+app.kubernetes.io/component: litmus-infra
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ template "litmus.name" . }}
+app.kubernetes.io/part-of: {{ template "litmus.name" . }} 
+app.kubernetes.io/version: "{{ .Chart.Version }}"
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }} 
+litmuschaos.io/version: {{ .Chart.AppVersion }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Specify default selectors
+*/}}
+{{- define "litmus.selectors" }}
+app.kubernetes.io/name: {{ template "litmus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/samples/chaos/charts/templates/clusterrole.yaml
+++ b/samples/chaos/charts/templates/clusterrole.yaml
@@ -1,0 +1,70 @@
+{{ if or (eq .Values.operatorMode "standard") (eq .Values.operatorMode "admin") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "litmus.fullname" . }}
+  labels:
+    app: {{ template "litmus.name" . }}
+    {{- include "litmus.labels" . | indent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["replicationcontrollers","secrets"]
+  verbs: ["get","list"]
+- apiGroups: ["apps.openshift.io"]
+  resources: ["deploymentconfigs"]
+  verbs: ["get","list"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "daemonsets", "replicasets", "statefulsets"]
+  verbs: ["get","list"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get","list","deletecollection"]
+- apiGroups: ["argoproj.io"]
+  resources: ["rollouts"]
+  verbs: ["get","list"]
+- apiGroups: [""]
+  resources: ["pods","configmaps","events","services"]
+  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
+- apiGroups: ["litmuschaos.io"]
+  resources: ["chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["list","get"]  
+{{ end }} 
+{{ if eq .Values.operatorMode "admin" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "litmus.fullname" . }}-admin
+  labels:
+    app: {{ template "litmus.name" . }}
+    {{- include "litmus.labels" . | indent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods","pods/exec","pods/eviction","events"]
+  verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+- apiGroups: ["litmuschaos.io"]
+  resources: ["chaosresults","chaosengines"]
+  verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+- apiGroups: [""]
+  resources: ["configmaps","secrets","services","pods/log"]
+  verbs: ["get","list","patch","update"]
+- apiGroups: ["apps"]
+  resources: ["replicasets","deployments","statefulsets"]
+  verbs: ["get","list","patch","update"]
+- apiGroups: ["litmuschaos.io"]
+  resources: ["chaosexperiments"]
+  verbs: ["get","list","patch","update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get","list","patch","update"]
+{{ end }}

--- a/samples/chaos/charts/templates/clusterrolebinding.yaml
+++ b/samples/chaos/charts/templates/clusterrolebinding.yaml
@@ -1,0 +1,36 @@
+{{ if or (eq .Values.operatorMode "standard") (eq .Values.operatorMode "admin") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "litmus.fullname" . }}
+  labels:
+    app: {{ template "litmus.name" . }}
+    {{- include "litmus.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "litmus.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "litmus.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}
+{{ if eq .Values.operatorMode "admin" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "litmus.fullname" . }}-admin
+  labels:
+    app: {{ template "litmus.name" . }}
+    {{- include "litmus.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "litmus.fullname" . }}-admin
+subjects:
+- kind: ServiceAccount
+  name: {{ include "litmus.fullname" . }}-admin
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/samples/chaos/charts/templates/deployment.yaml
+++ b/samples/chaos/charts/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "litmus.fullname" . }}
+  labels:
+    app: {{ template "litmus.name" . }}
+    {{- include "litmus.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "litmus.name" . }}
+      {{- include "litmus.selectors" . | indent 6 }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "litmus.name" . }}
+        {{- include "litmus.labels" . | indent 8 }}
+    spec:
+      serviceAccountName: {{ include "litmus.fullname" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.operatorName }}
+          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          command:
+          - chaos-operator
+          env:
+            - name: CHAOS_RUNNER_IMAGE
+              value: "{{ .Values.runner.image.repository }}:{{ .Values.runner.image.tag }}"
+          {{ if or (eq .Values.operatorMode "namespaced") ( eq .Values.operatorMode "admin") }}    
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{ else }}
+            - name: WATCH_NAMESPACE
+              value: 
+          {{ end }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "chaos-operator"
+          {{- if .Values.policies.monitoring.disabled }}
+            - name: ANALYTICS
+              value: "FALSE"
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/samples/chaos/charts/templates/namespaced-role.yaml
+++ b/samples/chaos/charts/templates/namespaced-role.yaml
@@ -1,0 +1,14 @@
+{{ if eq .Values.operatorMode "namespaced" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "litmus.fullname" . }}
+  labels:
+    app: {{ template "litmus.name" . }}
+    {{- include "litmus.labels" . | indent 4 }}
+rules:
+- apiGroups: ["","apps","batch","extensions","litmuschaos.io", "argoproj.io"]
+  resources: ["pods","pods/exec","pods/log","pods/eviction","jobs","deployments","daemonsets","statefulsets","events","configmaps","services","rollouts","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
+{{ end }}

--- a/samples/chaos/charts/templates/namespaced-rolebinding.yaml
+++ b/samples/chaos/charts/templates/namespaced-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{ if eq .Values.operatorMode "namespaced" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "litmus.fullname" . }}
+  labels:
+    app: {{ template "litmus.name" . }}
+    {{- include "litmus.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "litmus.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "litmus.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/samples/chaos/charts/templates/pod-delete-ce.yaml
+++ b/samples/chaos/charts/templates/pod-delete-ce.yaml
@@ -1,0 +1,17 @@
+{{ if not (has "pod-delete" .Values.experiments.disabled) }}
+---
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: pod-delete-chaos
+spec:
+  appinfo:
+    appns: "{{ .Values.appinfo.appns }}"
+    applabel: "{{ .Values.appinfo.applabel }}"
+    appkind: "{{ .Values.appinfo.appkind }}"
+  # It can be active/stop
+  engineState: 'active'
+  chaosServiceAccount: pod-delete-sa
+  experiments:
+    - name: pod-delete
+{{ end }}

--- a/samples/chaos/charts/templates/pod-delete-rbac.yaml
+++ b/samples/chaos/charts/templates/pod-delete-rbac.yaml
@@ -1,0 +1,59 @@
+{{ if not (has "pod-delete" .Values.experiments.disabled) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-delete-sa
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-delete-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+- apiGroups: [""]
+  resources: ["pods","events"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
+- apiGroups: [""]
+  resources: ["pods/exec","pods/log","replicationcontrollers"]
+  verbs: ["create","list","get"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create","list","get","delete","deletecollection"]
+- apiGroups: ["apps"]
+  resources: ["deployments","statefulsets","daemonsets","replicasets"]
+  verbs: ["list","get"]
+- apiGroups: ["apps.openshift.io"]
+  resources: ["deploymentconfigs"]
+  verbs: ["list","get"]
+- apiGroups: ["argoproj.io"]
+  resources: ["rollouts"]
+  verbs: ["list","get"]
+- apiGroups: ["litmuschaos.io"]
+  resources: ["chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-delete-sa
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-delete-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-delete-sa
+  namespace:  {{ .Release.Namespace }}
+{{ end }}

--- a/samples/chaos/charts/templates/pod-delete.yaml
+++ b/samples/chaos/charts/templates/pod-delete.yaml
@@ -1,0 +1,88 @@
+{{ if not (has "pod-delete" .Values.experiments.disabled) }}
+---
+apiVersion: litmuschaos.io/v1alpha1
+description:
+  message: |
+    Deletes a pod belonging to a deployment/statefulset/daemonset
+kind: ChaosExperiment
+metadata:
+  name: pod-delete
+  labels:
+    {{- include "litmus.labels" . | indent 4 }}
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      - apiGroups:
+          - ""
+          - "apps"
+          - "apps.openshift.io"
+          - "argoproj.io"
+          - "batch"
+          - "litmuschaos.io"
+        resources:
+          - "deployments"
+          - "jobs"
+          - "pods"
+          - "pods/log"
+          - "replicationcontrollers"
+          - "deployments"
+          - "statefulsets"
+          - "daemonsets"
+          - "replicasets"
+          - "deploymentconfigs"
+          - "rollouts"
+          - "pods/exec"
+          - "events"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "update"
+          - "delete"
+          - "deletecollection"
+    image: "{{ .Values.litmusGO.image.repository }}:{{ .Values.litmusGO.image.tag }}"
+    imagePullPolicy: {{ .Values.litmusGO.image.pullPolicy }}
+    args:
+    - -c
+    - ./experiments -name pod-delete
+    command:
+    - /bin/bash
+    env:
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '15'
+
+    # Period to wait before injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    - name: FORCE
+      value: 'true'
+
+    - name: CHAOS_INTERVAL
+      value: '5'
+
+    # Percentage of total pods to target
+    - name: PODS_AFFECTED_PERC
+      value: ''
+
+    - name: LIB
+      value: 'litmus'
+
+    - name: TARGET_PODS
+      value: ''
+
+    ## it defines the sequence of chaos execution for multiple target pods
+    ## supported values: serial, parallel
+    - name: SEQUENCE
+      value: 'parallel'      
+
+    labels:
+      name: pod-delete
+      app.kubernetes.io/part-of: litmus
+{{ end }}

--- a/samples/chaos/charts/templates/serviceaccount.yaml
+++ b/samples/chaos/charts/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "litmus.fullname" . }}
+  labels:
+    app: {{ template "litmus.name" . }}
+    {{- include "litmus.labels" . | indent 4 }}
+{{ if eq .Values.operatorMode "admin" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "litmus.fullname" . }}-admin
+  labels:
+    app: {{ template "litmus.name" . }}
+    {{- include "litmus.labels" . | indent 4 }}
+{{ end }}

--- a/samples/chaos/charts/values.yaml
+++ b/samples/chaos/charts/values.yaml
@@ -1,0 +1,84 @@
+# Default values for litmus.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: "litmus"
+fullnameOverride: "litmus"
+
+# -- Additional labels
+customLabels: {}
+
+operatorName: "chaos-operator"
+
+replicaCount: 1
+
+operator:
+  image:
+    repository: litmuschaos/chaos-operator
+    tag: 1.13.8
+    pullPolicy: Always
+runner:
+  image:
+    repository: litmuschaos/chaos-runner
+    tag: 1.13.8
+
+litmusGO:
+  image:
+    repository: litmuschaos/go-runner
+    tag: 1.13.8
+    pullPolicy: Always
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host:
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Supports: standard, admin, namespaced
+operatorMode: standard
+
+# Support for disabling google analytics
+# https://docs.litmuschaos.io/docs/faq-general/#does-litmus-track-any-usage-metrics-on-the-test-clusters
+policies:
+  monitoring:
+    disabled: false
+
+appinfo:
+  appns:
+  applabel:
+  appkind:
+  
+experiments:
+  disabled: []
+    


### PR DESCRIPTION
Signed-off-by: shubham chaudhary <shubham@chaosnative.com>

 Adding litmus chaos helm template. Which will install the following items:
- RBAC for all the resources
- litmus CRDs
- chaos-operator(control plane for litmus) [in namespace and  cluster scoped both]
- pod-delete experiment CR
- pod-delete engine CR

ref: #935 