### PR TITLE
update broken references after files were moved

### DIFF
--- a/samples/openshift/full-cicd/argocd-app.yaml
+++ b/samples/openshift/full-cicd/argocd-app.yaml
@@ -11,7 +11,7 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: samples/cicd
+    path: samples/openshift/full-cicd
     repoURL: https://github.com/MY_ORG/iter8
     targetRevision: master
   syncPolicy:

--- a/samples/openshift/full-cicd/tekton/tasks/start-experiment.yaml
+++ b/samples/openshift/full-cicd/tekton/tasks/start-experiment.yaml
@@ -31,7 +31,7 @@ spec:
       git config --global user.name 'Iter8'
       git clone https://$(params.USER):${GITHUB_TOKEN}@github.com/$(params.USER)/$(params.REPO) --branch=$(params.BRANCH)
       cd iter8
-      (cd samples/cicd/templates; VERSION=$(params.VERSION) make)
+      (cd samples/openshift/full-cicd/templates; VERSION=$(params.VERSION) make)
       #git checkout -b iter8_exp_start
       git add -A
       git commit -a -m 'start Iter8 experiment'

--- a/samples/openshift/full-cicd/tekton/triggertemplate.yaml
+++ b/samples/openshift/full-cicd/tekton/triggertemplate.yaml
@@ -27,7 +27,7 @@ spec:
           name: iter8-git
       params:
       - name: CONTEXT
-        value: samples/cicd/app
+        value: samples/openshift/full-cicd/app
       - name: ACTION
         value: $(tt.params.ACTION)
       - name: MERGED

--- a/samples/openshift/full-cicd/templates/experiment.yaml
+++ b/samples/openshift/full-cicd/templates/experiment.yaml
@@ -6,9 +6,8 @@ spec:
   # target identifies the service under experimentation using its fully qualified name
   target: default/productpage
   strategy:
-    # this experiment will perform an A/B test
-    testingPattern: Canary
-    deploymentPattern: FixedSplit
+    # this experiment will perform a conformance test
+    testingPattern: Conformance
     actions:
       start:
       # collect Iter8's built-in metrics
@@ -21,28 +20,43 @@ spec:
             url: "http://iter8-app-candidate.default.svc.cluster.local:8000"
       # when the experiment completes, promote the winning version in the Env repo
       finish:
-      - task: notification/http
+      - if: WinnerFound()
+        task: notification/http
         with:
-          url: https://api.github.com/repos/MY_ORG/iter8/actions/workflows/gitops-finish.yaml/dispatches
+          url: https://api.github.com/repos/MY_ORG/iter8/actions/workflows/gitops-finish-openshift.yaml/dispatches
           authType: Bearer
           secret: github-token
           body:  |
             {
               "ref":"master",
               "inputs":{
-                "basedir": "samples/cicd",
-                "filepath": "@<.filepath>@"
+                "basedir": "samples/openshift/full-cicd",
+                "filepath": "deployment-candidate.yaml"
               }
             }
           headers:
           - name: Accept
             value: application/vnd.github.v3+json
-          method: POST
+      - if: not WinnerFound()
+        task: notification/http
+        with:
+          url: https://api.github.com/repos/MY_ORG/iter8/actions/workflows/gitops-finish-openshift.yaml/dispatches
+          authType: Bearer
+          secret: github-token
+          body:  |
+            {
+              "ref":"master",
+              "inputs":{
+                "basedir": "samples/openshift/full-cicd",
+                "filepath": "deployment.yaml"
+              }
+            }
+          headers:
+          - name: Accept
+            value: application/vnd.github.v3+json
 
   criteria:
     requestCount: iter8-system/request-count
-    indicators:
-    - iter8-system/error-count
     objectives:
     - metric: iter8-system/mean-latency
       upperLimit: "500"
@@ -54,12 +68,4 @@ spec:
   versionInfo:
     # information about the app versions used in this experiment
     baseline:
-      name: iter8-app-stable
-      variables:
-      - name: filepath
-        value: deployment.yaml
-    candidates:
-    - name: iter8-app-candidate
-      variables:
-      - name: filepath
-        value: deployment-candidate.yaml
+      name: iter8-app-candidate


### PR DESCRIPTION
Fixes the following problems:
- Some references in yaml files were broken when other files moved around
- versionInfo variable substitution doesn't work anymore in notification/http task, so using WinnerFound() in experiment.yaml