### PR TITLE
iter8 k logs and iter8 k delete

### DIFF
--- a/basecli/k8s.tpl
+++ b/basecli/k8s.tpl
@@ -72,6 +72,14 @@ metadata:
     iter8.tools/app: {{ $app }}
 spec:
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: iter8
+        app.kubernetes.io/instance: {{ $id }}
+        app.kubernetes.io/version: "{{ $version }}"
+        app.kubernetes.io/component: pod
+        app.kubernetes.io/created-by: iter8
+        iter8.tools/app: {{ $app }}
     spec:
       containers:
       - name: iter8
@@ -110,7 +118,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  #resourceNames: ["{{ $name }}","{{ $name }}-result"]
+  resourceNames: ["{{ $name }}","{{ $name }}-result"]
   verbs: ["get", "list", "patch", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/iter8-tools/iter8/base/log"
+	"github.com/iter8-tools/iter8/basecli"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd *cobra.Command
+
+func getObjectManifests() ([]string, error) {
+	// use function of iter8 gen k8s to create manifest
+	generatedManifest, err := basecli.Generate([]string{fmt.Sprintf("%s=%s", "id", k8sExperimentOptions.experimentId)})
+	if err != nil {
+		return []string{}, err
+	}
+	// split into objects (as strings)
+	objectManifests := strings.Split(generatedManifest.String(), "---")
+
+	return objectManifests, nil
+}
+
+func deleteObject(dr dynamic.ResourceInterface, kind string, name string) (err error) {
+	deletePolicy := metav1.DeletePropagationForeground
+	var gracePeriod int64 = 0
+	err = dr.Delete(context.Background(), name, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &deletePolicy})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			// don't report error if didn't exist in the first place
+			log.Logger.Errorf("delete failed: %s\n", err.Error())
+		}
+	}
+	log.Logger.Info(fmt.Sprintf("deleted %s/%s\n", strings.ToLower(kind), name))
+
+	return nil
+}
+
+func deleteObjects() (err error) {
+	manifests, err := getObjectManifests()
+	if err != nil {
+		return err
+	}
+
+	// get rest.Config
+	restConfig, err := k8sExperimentOptions.ConfigFlags.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	// get RESTMapper to find GVR
+	dc, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+
+	// prepare dynamic client
+	dyn, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	decoder := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	for _, manifest := range manifests {
+		// convert manifest (string) to obj (unstructured) and get GVK
+		obj := &unstructured.Unstructured{}
+		_, gvk, err := decoder.Decode([]byte(manifest), nil, obj)
+		if err != nil {
+			return err
+		}
+
+		// find GVR from GVK
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return err
+		}
+
+		// obtain REST interface for the GVR
+		var dr dynamic.ResourceInterface
+		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+			// namespaced resources
+			dr = dyn.Resource(mapping.Resource).Namespace(k8sExperimentOptions.namespace)
+		} else {
+			// cluster-wide resources; should not happen for iter8 use cases, but just to be sure
+			dr = dyn.Resource(mapping.Resource)
+		}
+
+		// do the delete; quit at first error (some objects may remain)
+		err = deleteObject(dr, gvk.Kind, obj.GetName())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	// initialize deleteCmd
+	deleteCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete experiment",
+		Example: `
+# Delete most recent experiment
+iter8 k delete
+
+# Delete experient with identifier $EXPERIMENT_ID
+iter8 k delete -e $EXPERIMENT_ID`,
+		RunE: func(c *cobra.Command, args []string) error {
+			k8sExperimentOptions.initK8sExperiment(true)
+			return deleteObjects()
+		},
+	}
+	k8sExperimentOptions.addExperimentIdOption(deleteCmd.Flags())
+
+	// deleteCmd is now initialized
+	kCmd.AddCommand(deleteCmd)
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/iter8-tools/iter8/base/log"
+
+	"github.com/spf13/cobra"
+)
+
+var logsCmd *cobra.Command
+
+func init() {
+	// initialize logsCmd
+	logsCmd = &cobra.Command{
+		Use:   "logs",
+		Short: "Get logs from experiment",
+		Example: `
+# Get logs of more recent experiment running in Kubernetes
+iter8 k logs
+
+# Get logs of more experiment running in Kubernetes with identifier
+iter8 k logs -e identifier`,
+		RunE: func(c *cobra.Command, args []string) error {
+			k8sExperimentOptions.initK8sExperiment(true)
+			log.Logger.Infof("logs for experiment: %s\n", k8sExperimentOptions.experimentId)
+			return GetExperimentLogs(k8sExperimentOptions.client, k8sExperimentOptions.namespace, k8sExperimentOptions.experimentId)
+		},
+	}
+	k8sExperimentOptions.addExperimentIdOption(logsCmd.Flags())
+
+	// logsCmd is now initialized
+	kCmd.AddCommand(logsCmd)
+}


### PR DESCRIPTION
Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>

- `iter8 k logs`
- `iter8 k delete`
- update to `iter8 k get` to sort by creation time by default
- fix to default selection of experiment when `-e` is not specified