### PR TITLE
rename option experiment-id to id

### DIFF
--- a/basecli/k8s.go
+++ b/basecli/k8s.go
@@ -17,8 +17,6 @@ import (
 const (
 	// Path to go template file
 	k8sTemplateFilePath = "k8s.tpl"
-	// Path to experiment file
-	experimentFilePath = "experiment.yaml"
 )
 
 type k8sExperiment struct {

--- a/basecli/k8s.go
+++ b/basecli/k8s.go
@@ -17,13 +17,16 @@ import (
 const (
 	// Path to go template file
 	k8sTemplateFilePath = "k8s.tpl"
-	experimentFilePath  = "experiment.yaml"
+	// Path to experiment file
+	experimentFilePath = "experiment.yaml"
 )
 
 type k8sExperiment struct {
 	Tasks  []base.TaskSpec
 	Values chartutil.Values
 }
+
+var id string
 
 // run runs the command
 func runGetK8sCmd(cmd *cobra.Command, args []string) (err error) {
@@ -39,6 +42,14 @@ func runGetK8sCmd(cmd *cobra.Command, args []string) (err error) {
 
 func Generate(values []string) (result *bytes.Buffer, err error) {
 	v := chartutil.Values{}
+
+	// add id=id if --id option used
+	// note that if both --id=foo and --set id=bar are used,
+	// the --id option will take precedence
+	if len(id) > 0 {
+		values = append(values, "id="+id)
+	}
+
 	err = ParseValues(values, v)
 	if err != nil {
 		return nil, err
@@ -110,6 +121,9 @@ iter8 gen k8s`,
 }
 
 func init() {
+	// support --id option to set identifier
+	k8sCmd.Flags().StringVarP(&id, "id", "i", "", "if not specified, a randomly generated identifier will be used")
+
 	// extend gen command with the k8s command
 	genCmd.AddCommand(k8sCmd)
 }

--- a/basecli/k8s.tpl
+++ b/basecli/k8s.tpl
@@ -91,7 +91,7 @@ spec:
         command:
         - "/bin/sh"
         - "-c"
-        - iter8 k run -e {{ $id }}  # run experiment using remote secret
+        - iter8 k run --id {{ $id }}  # run experiment using remote secret
       restartPolicy: Never
   backoffLimit: 0
 ---

--- a/cmd/assert.go
+++ b/cmd/assert.go
@@ -25,14 +25,14 @@ iter8 k assert -c completed,nofailure,slos
 # for experiments with multiple versions, specify that the SLOs for one version were satisfied
 iter8 k assert -c completed,nofailure,slosby=0
 
-# the above assertion for an experiment with identifier $EXPERIMENT_ID
-iter8 k assert -e $EXPERIMENT_ID -c completed,nofailure,slosby=0
+# the above assertion for an experiment with identifier $ID
+iter8 k assert --id $ID -c completed,nofailure,slosby=0
 
 # the above assertion with a runtime timeout
-iter8 k assert -e $EXPERIMENT_ID -c completed,nofailure,slosby=0 -t 5s`
+iter8 k assert --id $ID -c completed,nofailure,slosby=0 -t 5s`
 	assertCmd.RunE = func(c *cobra.Command, args []string) error {
 		k8sExperimentOptions.initK8sExperiment(true)
-		log.Logger.Infof("evaluating assert for experiment: %s\n", k8sExperimentOptions.experimentId)
+		log.Logger.Infof("evaluating assert for experiment: %s\n", k8sExperimentOptions.id)
 		allGood, err := k8sExperimentOptions.experiment.Assert(basecli.AssertOptions.Conds, basecli.AssertOptions.Timeout)
 		if err != nil || !allGood {
 			return err
@@ -44,7 +44,7 @@ iter8 k assert -e $EXPERIMENT_ID -c completed,nofailure,slosby=0 -t 5s`
 
 		return nil
 	}
-	k8sExperimentOptions.addExperimentIdOption(assertCmd.Flags())
+	k8sExperimentOptions.addIdOption(assertCmd.Flags())
 
 	// assertCmd is now initialized
 	kCmd.AddCommand(assertCmd)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -25,7 +25,7 @@ var deleteCmd *cobra.Command
 
 func getObjectManifests() ([]string, error) {
 	// use function of iter8 gen k8s to create manifest
-	generatedManifest, err := basecli.Generate([]string{fmt.Sprintf("%s=%s", "id", k8sExperimentOptions.experimentId)})
+	generatedManifest, err := basecli.Generate([]string{fmt.Sprintf("%s=%s", "id", k8sExperimentOptions.id)})
 	if err != nil {
 		return []string{}, err
 	}
@@ -119,15 +119,15 @@ func init() {
 # Delete experiment most recently started in Kubernetes cluster
 iter8 k delete
 
-# Delete experient with identifier $EXPERIMENT_ID
-iter8 k delete -e $EXPERIMENT_ID`,
+# Delete experient with identifier $ID
+iter8 k delete --id $ID`,
 		RunE: func(c *cobra.Command, args []string) error {
 			k8sExperimentOptions.initK8sExperiment(true)
-			log.Logger.Infof("deleting experiment: %s\n", k8sExperimentOptions.experimentId)
+			log.Logger.Infof("deleting experiment: %s\n", k8sExperimentOptions.id)
 			return deleteObjects()
 		},
 	}
-	k8sExperimentOptions.addExperimentIdOption(deleteCmd.Flags())
+	k8sExperimentOptions.addIdOption(deleteCmd.Flags())
 
 	// deleteCmd is now initialized
 	kCmd.AddCommand(deleteCmd)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -67,12 +67,13 @@ func init() {
 		Example: `
 # Get list of experiments running in a Kubernetes cluster
 iter8 k get`,
+		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			k8sExperimentOptions.initK8sExperiment(true)
 			return runGetCmd(c, args, k8sExperimentOptions)
 		},
 	}
-	k8sExperimentOptions.addExperimentIdOption(getCmd.Flags())
+	k8sExperimentOptions.addIdOption(getCmd.Flags())
 
 	// getCmd is now initialized
 	kCmd.AddCommand(getCmd)

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -236,24 +236,17 @@ func (f *KubernetesExpIO) WriteResult(r *basecli.Experiment) error {
 	return err
 }
 
-const (
-	ExperimentId            = "experiment-id"
-	ExperimentIdShort       = "e"
-	ExperimentIdDescription = "remote experiment identifier; if not specified, the most recent experiment is used"
-)
-
-func (o *K8sExperimentOptions) addExperimentIdOption(p *pflag.FlagSet) {
-	// Add options
-	p.StringVarP(&o.experimentId, ExperimentId, ExperimentIdShort, "", ExperimentIdDescription)
+func (o *K8sExperimentOptions) addIdOption(p *pflag.FlagSet) {
+	p.StringVarP(&o.id, "id", "i", "", "experiment identifier; if not specified, the most recent experiment is used")
 }
 
 type K8sExperimentOptions struct {
-	ConfigFlags  *genericclioptions.ConfigFlags
-	namespace    string
-	client       *kubernetes.Clientset
-	experimentId string
-	expIO        *KubernetesExpIO
-	experiment   *basecli.Experiment
+	ConfigFlags *genericclioptions.ConfigFlags
+	namespace   string
+	client      *kubernetes.Clientset
+	id          string
+	expIO       *KubernetesExpIO
+	experiment  *basecli.Experiment
 }
 
 func newK8sExperimentOptions() *K8sExperimentOptions {
@@ -273,18 +266,18 @@ func (o *K8sExperimentOptions) initK8sExperiment(withResult bool) (err error) {
 		return err
 	}
 
-	if len(o.experimentId) == 0 {
-		s, err := GetExperimentSecret(o.client, o.namespace, o.experimentId)
+	if len(o.id) == 0 {
+		s, err := GetExperimentSecret(o.client, o.namespace, o.id)
 		if err != nil {
 			return err
 		}
-		o.experimentId = s.Labels[IdLabel]
+		o.id = s.Labels[IdLabel]
 	}
 
 	o.expIO = &KubernetesExpIO{
 		Client:    o.client,
 		Namespace: o.namespace,
-		Name:      SpecSecretPrefix + o.experimentId,
+		Name:      SpecSecretPrefix + o.id,
 	}
 
 	o.experiment, err = basecli.Build(withResult, o.expIO)

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -17,15 +17,15 @@ func init() {
 # Get logs of the most recent experiment started in a Kubernetes cluster
 iter8 k logs
 
-# Get logs of the experiment running in a Kubernetes with identifier $EXPERIMENT_ID
-iter8 k logs -e $EXPERIMENT_ID`,
+# Get logs of the experiment running in a Kubernetes with identifier $ID
+iter8 k logs --id $ID`,
 		RunE: func(c *cobra.Command, args []string) error {
 			k8sExperimentOptions.initK8sExperiment(true)
-			log.Logger.Infof("logs for experiment: %s\n", k8sExperimentOptions.experimentId)
-			return GetExperimentLogs(k8sExperimentOptions.client, k8sExperimentOptions.namespace, k8sExperimentOptions.experimentId)
+			log.Logger.Infof("logs for experiment: %s\n", k8sExperimentOptions.id)
+			return GetExperimentLogs(k8sExperimentOptions.client, k8sExperimentOptions.namespace, k8sExperimentOptions.id)
 		},
 	}
-	k8sExperimentOptions.addExperimentIdOption(logsCmd.Flags())
+	k8sExperimentOptions.addIdOption(logsCmd.Flags())
 
 	// logsCmd is now initialized
 	kCmd.AddCommand(logsCmd)

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -19,17 +19,17 @@ iter8 k report
 # Generate an html report for the most recent experiment
 iter8 k report -o html
 
-# Generate an html report the experiment with identifier $EXPERIMENT_ID
-iter8 k report -o html -e $EXPERIMENT_ID`
+# Generate an html report the experiment with identifier $ID
+iter8 k report -o html --id $ID`
 	reportCmd.SilenceErrors = true
 
 	reportCmd.RunE = func(c *cobra.Command, args []string) error {
 		k8sExperimentOptions.initK8sExperiment(true)
-		log.Logger.Infof("generating report for experiment: %s\n", k8sExperimentOptions.experimentId)
+		log.Logger.Infof("generating report for experiment: %s\n", k8sExperimentOptions.id)
 		return k8sExperimentOptions.experiment.Report(basecli.ReportOptions.OutputFormat)
 	}
 
-	k8sExperimentOptions.addExperimentIdOption(reportCmd.Flags())
+	k8sExperimentOptions.addIdOption(reportCmd.Flags())
 
 	// reportCmd is now initialized
 	kCmd.AddCommand(reportCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,14 +14,14 @@ func init() {
 
 	runCmd.Hidden = true
 	runCmd.Example = `
-# Run experiment with identifier $EXPERIMENT_ID defined in a Kubernetes secret named "experiment-$EXPERIMENT_ID"
-iter8 k run -e $EXPERIMENT_ID`
+# Run experiment with identifier $ID defined in a Kubernetes secret named "experiment-$ID"
+iter8 k run --id $ID`
 	runCmd.RunE = func(c *cobra.Command, args []string) error {
 		k8sExperimentOptions.initK8sExperiment(false)
 		return k8sExperimentOptions.experiment.Run(k8sExperimentOptions.expIO)
 	}
 
-	k8sExperimentOptions.addExperimentIdOption(runCmd.Flags())
+	k8sExperimentOptions.addIdOption(runCmd.Flags())
 
 	// runCmd is now initialized
 	kCmd.AddCommand(runCmd)


### PR DESCRIPTION
Rename option `--experiment-id` to `--id`
Add `--id` option to `iter8 gen k8s`

Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>