### PR TITLE
Fixing hub command to not break after v0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Iter8 experiments make it simple to collect performance and business metrics for
 Experiment charts are specialized [Helm charts](https://helm.sh/docs/topics/charts/) that contain reusable experiment templates. Iter8 combines experiment charts with user supplied values to generate runnable `experiment.yaml` files.
 
 #### Iter8 Hub
-Iter8 hub is a specific location within in the [Iter8 GitHub repo](https://github.com/iter8-tools/iter8) that hosts several pre-packaged and reusable charts. These charts enable to you to launch powerful release optimization experiments in seconds. Their usage is described in depth in various [Iter8 tutorials](https://iter8.tools/latest/tutorials/load-test-http/overview/).
+Iter8 hub is a specific location within in the [Iter8 GitHub repo](https://github.com/iter8-tools/iter8) that hosts several pre-packaged and reusable charts. These charts enable to you to launch powerful release optimization experiments in seconds. Their usage is described in depth in various [Iter8 tutorials](https://iter8.tools/0.8/tutorials/load-test-http/usage/).
 
 ## Features at a glance
 

--- a/basecli/version.go
+++ b/basecli/version.go
@@ -10,9 +10,11 @@ import (
 var short bool
 
 var (
-	// Version is intended to be set using LDFLAGS at build time
+	// version is intended to be set using LDFLAGS at build time
 	// In the absence of complete semantic versioning info, the best we can do is major minor
 	version = "v0.8"
+	// lastKnownPatchVersion is the last known patch version for this minor release
+	lastKnownPatchVersion = "v0.8.33"
 	// version is the current major/minor version of Iter8
 	// set this manually whenever the major or minor version changes
 	majorMinor = "v0.8"

--- a/mkdocs/docs/getting-started/concepts.md
+++ b/mkdocs/docs/getting-started/concepts.md
@@ -17,7 +17,7 @@ Iter8 experiments make it simple to collect performance and business metrics for
 Experiment charts are specialized [Helm charts](https://helm.sh/docs/topics/charts/) that contain reusable experiment templates. Iter8 combines experiment charts with user supplied values to generate runnable `experiment.yaml` files.
 
 #### Iter8 Hub
-Iter8 hub is a specific location within in the [Iter8 GitHub repo](https://github.com/iter8-tools/iter8) that hosts several pre-packaged and reusable charts. These charts enable to you to launch powerful release optimization experiments in seconds. Their usage is described in depth in various [Iter8 tutorials](https://iter8.tools/latest/tutorials/load-test-http/overview/).
+Iter8 hub is a specific location within in the [Iter8 GitHub repo](https://github.com/iter8-tools/iter8) that hosts several pre-packaged and reusable charts. These charts enable to you to launch powerful release optimization experiments in seconds. Their usage is described in depth in various [Iter8 tutorials](https://iter8.tools/0.8/tutorials/load-test-http/usage/).
 
 ## Features at a glance
 


### PR DESCRIPTION
1. Ensure hub command will not break when we release v0.9
2. Fix links