### PR TITLE
moving experiment charts into iter8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,3 @@ iter8
 **/ghz-call-data.json
 **/ghz-call-data.bin
 **/ghz-call-metadata.json
-
-**/load-test-http/

--- a/charts/iter8lib/.helmignore
+++ b/charts/iter8lib/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/iter8lib/Chart.yaml
+++ b/charts/iter8lib/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: iter8lib
+version: 0.9.0
+description: Iter8 library chart
+type: library
+home: https://iter8.tools
+sources:
+- https://github.com/iter8-tools/iter8
+maintainers:
+- name: Srinivasan Parthasarathy
+  email: spartha@us.ibm.com
+  url: https://researcher.watson.ibm.com/researcher/view.php?person=us-spartha
+icon: https://github.com/iter8-tools/iter8/raw/master/mkdocs/docs/images/favicon.png
+appVersion: v0.9
+

--- a/charts/iter8lib/README.md
+++ b/charts/iter8lib/README.md
@@ -1,0 +1,18 @@
+# Iter8 library chart
+
+> This chart provides reusable templates that are used by Iter8 experiment charts. Experiments can be composed by using this chart as a dependency, and by including templates available in this library chart.
+
+**Templates for Iter8 tasks:** 
+
+- `task.http`: The `gen-load-and-collect-metrics-http` task
+- `task.grpc`: The `gen-load-and-collect-metrics-grpc` task
+- `task.assess`: The `assess-app-versions` task
+
+**Templates for Kubernetes experiments:**
+
+- `k.job`: Kubernetes experiment job
+- `k.spec.secret`: Kubernetes secret containing experiment spec
+- `k.spec.role`: Role for Kubernetes spec secret
+- `k.spec.rolebinding`: Role binding for Kubernetes spec secret
+- `k.result.role`: Role for Kubernetes result secret
+- `k.result.rolebinding`: Role binding for Kubernetes result secret

--- a/charts/iter8lib/templates/_k-job.tpl
+++ b/charts/iter8lib/templates/_k-job.tpl
@@ -1,0 +1,21 @@
+{{- define "k.job" -}}
+{{- $name := printf "%v-%v" .Release.Name .Release.Revision -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: iter8
+        image: iter8-tools/iter8:{{  trimPrefix "v" .Chart.AppVersion }}
+        imagePullPolicy: Always
+        command:
+        - "/bin/sh"
+        - "-c"
+        - |
+          iter8 k run --namespace {{ .Release.Namespace }} --group {{ .Release.Name }} --revision {{ .Release.Revision }}
+      restartPolicy: Never
+  backoffLimit: 0
+{{- end -}}

--- a/charts/iter8lib/templates/_k-manifest.tpl
+++ b/charts/iter8lib/templates/_k-manifest.tpl
@@ -1,0 +1,13 @@
+{{- define "k.manifest" -}}
+{{- include "k.job" . }}
+---
+{{- include "k.spec.secret" . }}
+---
+{{- include "k.spec.role" . }}
+---
+{{- include "k.spec.rolebinding" . }}
+---
+{{- include "k.result.role" . }}
+---
+{{- include "k.result.rolebinding" . }}
+{{- end -}}

--- a/charts/iter8lib/templates/_k-result-role.tpl
+++ b/charts/iter8lib/templates/_k-result-role.tpl
@@ -1,0 +1,12 @@
+{{- define "k.result.role" -}}
+{{- $name := printf "%v-%v" .Release.Name .Release.Revision -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}-result-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["{{ $name }}-result"]
+  verbs: ["create", "get", "update"]
+{{- end -}}

--- a/charts/iter8lib/templates/_k-result-rolebinding.tpl
+++ b/charts/iter8lib/templates/_k-result-rolebinding.tpl
@@ -1,0 +1,14 @@
+{{- define "k.result.rolebinding" -}}
+{{- $name := printf "%v-%v" .Release.Name .Release.Revision -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}-result-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: {{ $name }}-result-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/iter8lib/templates/_k-spec-role.tpl
+++ b/charts/iter8lib/templates/_k-spec-role.tpl
@@ -1,0 +1,12 @@
+{{- define "k.spec.role" -}}
+{{- $name := printf "%v-%v" .Release.Name .Release.Revision -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}-spec-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["{{ $name }}-spec"]
+  verbs: ["get"]
+{{- end -}}

--- a/charts/iter8lib/templates/_k-spec-rolebinding.tpl
+++ b/charts/iter8lib/templates/_k-spec-rolebinding.tpl
@@ -1,0 +1,14 @@
+{{- define "k.spec.rolebinding" -}}
+{{- $name := printf "%v-%v" .Release.Name .Release.Revision -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}-spec-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: {{ $name }}-spec-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/iter8lib/templates/_k-spec-secret.tpl
+++ b/charts/iter8lib/templates/_k-spec-secret.tpl
@@ -1,0 +1,10 @@
+{{- define "k.spec.secret" -}}
+{{- $name := printf "%v-%v" .Release.Name .Release.Revision -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}-spec
+stringData:
+  experiment.yaml: |
+{{ include "experiment" . | indent 4 }}
+{{- end -}}

--- a/charts/iter8lib/templates/_task-assess.tpl
+++ b/charts/iter8lib/templates/_task-assess.tpl
@@ -1,0 +1,14 @@
+{{- define "task.assess" -}}
+{{- if .Values.SLOs }}
+# task: validate service level objectives for app using
+# the metrics collected in an earlier task
+- task: assess-app-versions
+  with:
+    SLOs:
+    {{- range $key, $value := .Values.SLOs }}
+    - metric: {{ $key | toString }}
+      upperLimit: {{ $value | float64 }}
+    {{- end }}
+{{- end }}
+{{- end -}}
+

--- a/charts/iter8lib/templates/_task-grpc.tpl
+++ b/charts/iter8lib/templates/_task-grpc.tpl
@@ -1,0 +1,111 @@
+{{- define "task.grpc" -}}
+# task: generate gRPC requests for the given gRPC method
+# collect Iter8's built-in gRPC latency and error-related metrics
+- task: gen-load-and-collect-metrics-grpc
+  with:
+
+    {{- if .Values.protoFile }}
+    proto: {{ .Values.protoFile | toString }}
+    {{- end }}
+
+    {{- if .Values.protoURL }}
+    protoURL: {{ .Values.protoURL | toString }}
+    {{- end }}
+
+    {{- if .Values.protosetFile }}
+    protoset: {{ .Values.protosetFile | toString }}
+    {{- end }}
+
+    {{- if .Values.protosetURL }}
+    protosetURL: {{ .Values.protosetURL | toString }}
+    {{- end }}
+
+    {{- if .Values.total }}
+    total: {{ .Values.total | int }}
+    {{- end }}
+
+    {{- if .Values.rps }}
+    rps: {{ .Values.rps | int }}
+    {{- end }}
+
+    {{- if .Values.concurrency }}
+    concurrency: {{ .Values.concurrency | int }}
+    {{- end }}
+
+    {{- if .Values.connections }}
+    connections: {{ .Values.connections | int }}
+    {{- end }}
+
+    {{- if .Values.duration }}
+    duration: {{ .Values.duration | toString }}
+    {{- end }}
+
+    {{- if .Values.maxDuration }}
+    max-duration: {{ .Values.maxDuration | toString }}
+    {{- end }}
+
+    {{- if .Values.streamInterval }}
+    stream-interval: {{ .Values.streamInterval | toString }}
+    {{- end }}
+
+    {{- if .Values.streamCallDuration }}
+    stream-call-duration: {{ .Values.streamCallDuration | toString }}
+    {{- end }}
+
+    {{- if .Values.streamCallCount }}
+    stream-call-count: {{ .Values.streamCallCount | int }}
+    {{- end }}
+
+    {{- if .Values.connectTimeout }}
+    connect-timeout: {{ .Values.connectTimeout | toString }}
+    {{- end }}
+
+    {{- if .Values.keepalive }}
+    keepalive: {{ .Values.keepalive | toString }}
+    {{- end }}
+
+    {{- if .Values.data }}
+    data:
+{{ toYaml .Values.data | indent 6 }}
+    {{- end }}
+
+    {{- if .Values.dataFile }}
+    data-file: {{ .Values.dataFile | toString }}
+    {{- end }}
+
+    {{- if .Values.dataURL }}
+    dataURL: {{ .Values.dataURL | toString }}
+    {{- end }}
+
+    {{- if .Values.binaryDataFile }}
+    binary-file: {{ .Values.binaryDataFile | toString }}
+    {{- end }}
+
+    {{- if .Values.binaryDataURL }}
+    binaryDataURL: {{ .Values.binaryDataURL | toString }}
+    {{- end }}
+
+    {{- if .Values.metadata }}
+    metadata:
+{{ toYaml .Values.metadata | indent 6 }}
+    {{- end }}
+
+    {{- if .Values.metadataFile }}
+    metadata-file: {{ .Values.metadataFile | toString }}
+    {{- end }}
+
+    {{- if .Values.metadataURL }}
+    metadataURL: {{ .Values.metadataURL | toString }}
+    {{- end }}
+
+    {{- if .Values.reflectMetadata }}
+    reflectMetadata:
+{{ toYaml .Values.reflectMetadata | indent 6 }}
+    {{- end }}
+
+    {{- ""}}
+    versionInfo:
+    - host: {{ required "A valid host is required!" .Values.host | toString }}
+      call: {{ required "A valid call is required!" .Values.call | toString }}
+{{- end -}}    
+

--- a/charts/iter8lib/templates/_task-http.tpl
+++ b/charts/iter8lib/templates/_task-http.tpl
@@ -1,0 +1,59 @@
+{{- define "task.http" -}}
+# task: generate HTTP requests for application URL
+# collect Iter8's built-in HTTP latency and error-related metrics
+- task: gen-load-and-collect-metrics-http
+  with:
+
+    {{- if .Values.numQueries }}
+    numRequests: {{ .Values.numQueries | int }}
+    {{- end }}
+
+    {{- if .Values.duration }}
+    duration: {{ .Values.duration | toString }}
+    {{- end }}
+
+    {{- if .Values.qps }}
+    qps: {{ .Values.qps | float64 }}
+    {{- end }}
+
+    {{- if .Values.connections }}
+    connections: {{ .Values.connections | int }}
+    {{- end }}
+
+    {{- if .Values.payloadStr }}
+    payloadStr: {{ .Values.payloadStr | toString }}
+    {{- end }}
+
+    {{- if .Values.payloadURL }}
+    payloadURL: {{ .Values.payloadURL | toString }}
+    {{- end }}
+
+    {{- if .Values.contentType }}
+    contentType: {{ .Values.contentType | toString }}
+    {{- end }}
+
+    {{- if .Values.errorsAbove }}
+    errorRanges:
+    - lower: {{ .Values.errorsAbove | int }}
+    {{- end }}
+
+    {{- $percentiles := list }}
+    {{- range $key, $value := .Values.SLOs }}
+    {{- if (regexMatch "http/latency-p\\d+(?:\\.\\d)?$" $key) }}
+    {{- $percentiles = append $percentiles (trimPrefix "http/latency-p" $key | float64 ) }}
+    {{- end }}
+    {{- end }}
+    {{- if $percentiles }}
+    percentiles:
+{{ toYaml ($percentiles | uniq) | indent 4 }}
+    {{- end }}
+
+    {{- ""}}
+    versionInfo:
+    - url: {{ required "A valid url value is required!" .Values.url | toString }}
+    {{- if .Values.headers }}
+      headers:
+{{ toYaml .Values.headers | indent 8 }}
+    {{- end }}
+{{- end -}}    
+

--- a/charts/load-test-grpc/.helmignore
+++ b/charts/load-test-grpc/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# generated files need to be ignored
+experiment.yaml

--- a/charts/load-test-grpc/Chart.yaml
+++ b/charts/load-test-grpc/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: load-test-grpc
+version: 0.9.1
+description: Load test, benchmark, and validate gRPC services
+type: application
+keywords:
+- Iter8
+- gRPC
+- load test
+- benchmark
+- validation
+- SLOs 
+- metrics
+- experiment
+home: https://iter8.tools
+sources:
+- https://github.com/iter8-tools/iter8
+maintainers:
+- name: Srinivasan Parthasarathy
+  email: spartha@us.ibm.com
+  url: https://researcher.watson.ibm.com/researcher/view.php?person=us-spartha
+icon: https://github.com/iter8-tools/iter8/raw/master/mkdocs/docs/images/favicon.png
+dependencies:
+- name: iter8lib
+  version: 0.9.x
+  repository: file://../
+appVersion: v0.9

--- a/charts/load-test-grpc/templates/_experiment.tpl
+++ b/charts/load-test-grpc/templates/_experiment.tpl
@@ -1,0 +1,4 @@
+{{ define "experiment" -}}
+{{- include "task.grpc" . -}}
+{{- include "task.assess" . -}}
+{{ end }}

--- a/charts/load-test-grpc/templates/k8s.yaml
+++ b/charts/load-test-grpc/templates/k8s.yaml
@@ -1,0 +1,1 @@
+{{- include "k.manifest" . }}

--- a/charts/load-test-grpc/values.yaml
+++ b/charts/load-test-grpc/values.yaml
@@ -1,0 +1,115 @@
+### Defaults values for this experiment chart.
+
+### The documentation follows Helm recommendations described in the URL below.
+### https://helm.sh/docs/chart_best_practices/values/#document-valuesyaml 
+
+##################################
+
+### protoFile  Protocol Buffer .proto file that defines the gRPC service. 
+### Example: /user/me/helloworld.proto
+protoFile: null
+
+### protoURL  URL of Protocol Buffer .proto file that defines the gRPC service.
+### Example: https://user.me/helloworld.proto
+protoURL: null
+
+### protosetFile  .protoset file compiled from one or more .proto source files.
+### Example: /user/me/allworlds.protoset
+protosetFile: null
+
+### protosetURL  URL of .protoset file compiled from one or more .proto source files.
+### Example:  https://user.me/allworlds.protoset
+protosetURL: null
+
+### total Number of requests. 
+### If unspecified, a default value of 200 will be used.
+total:  null
+
+### rps Number of requests per second (RPS). 
+### If unspecified, or set to zero, then there will be no rate limit.
+### The rps will be distributed among all the workers (see concurrency).
+rps:  null
+
+### concurrency Number of workers to run concurrently.
+### If unspecified, a default value of 50 will be used.
+concurrency:  null
+
+### connections Number of connections to use.
+### Concurrency is distributed evenly among all the connections.
+### If unspecified, a default value of 1 will be used.
+connections:  null
+
+### duration Duration for the experiment to send requests. 
+### When duration is reached, experiment stops sending requests. 
+### If duration is specified, 'total' is ignored. Examples: 10s, 3m.
+duration: null
+
+### maxDuration Maximum duration for the experiment to send requests 
+### with 'total' setting respected. 
+### If duration is reached before 'total' requests are completed, 
+### experiment stops sending requests. Examples: 10s, 3m.
+maxDuration: null
+
+### streamInterval Interval between message sends in stream requests. Example: 1s
+streamInterval: null
+
+### streamCallDuration Duration after which experiment will close the stream in each streaming call. Example: 30s
+streamCallDuration: null
+
+### streamCallCount Count of messages sent, after which client will close the stream in each streaming call.
+streamCallCount: null
+
+### connectTimeout  Connection timeout duration for the initial connection dial.
+### If unspecified, a default value of 10s is used. Example: 20s
+connectTimeout: null
+
+### keepalive  Keepalive time duration. Only used if present and above 0s.
+keepalive: null
+
+### host  Host and port of the gRPC service
+### This field is required.
+host: null
+
+### call  Fully-qualified method name.
+### Specified in 'package.Service/method' or 'package.Service.Method' format.
+### This field is required.
+call: null
+
+### data  Call data YAML object.
+data: null
+
+### dataFile File path for call data JSON file.
+### Examples: /home/user/file.json or ./file.json.
+dataFile: null
+
+### dataURL URL of the call data JSON file.
+dataURL: null
+
+### binaryDataFile File path for the call data as serialized binary message or multiple count-prefixed messages.
+### Examples: /home/user/file.bin or ./file.bin
+binaryDataFile: null
+
+### binaryDataURL URL of the call data as serialized binary message or multiple count-prefixed messages.
+binaryDataURL: null
+
+### metadata  Call metadata YAML object in the map[string]string format.
+metadata: null
+
+### metadataFile File path for call metadata JSON file.
+### Examples: /home/user/metadata.json or ./metadata.json
+metadataFile: null
+
+### metadataURL URL of the call metadata JSON file.
+metadataURL: null
+
+### SLOs  A map of service level objectives (SLOs) that the app needs to satisfy.
+### Keys are metric names. Values are acceptable upper limits for the metric.
+### Valid metric names are grpc/error-rate, grpc/error-count, 
+### grpc/latency/max, grpc/latency/mean, grpc/latency/stddev, and grpc/latency/pX, 
+### where X is any percentile (i.e., any float value between 0 and 100).
+### Unit of latency is msec.
+### Example:
+###   grpc/error-rate: 0
+###   grpc/latency/mean: 50
+###   grpc/latency/p99: 200
+SLOs: null

--- a/charts/load-test-http/.helmignore
+++ b/charts/load-test-http/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# generated files need to be ignored
+experiment.yaml

--- a/charts/load-test-http/Chart.yaml
+++ b/charts/load-test-http/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: load-test-http
+version: 0.9.1
+description: Load test, benchmark, and validate HTTP services
+type: application
+keywords:
+- Iter8
+- HTTP
+- load test
+- benchmark
+- validation
+- SLOs 
+- metrics
+- experiment
+home: https://iter8.tools
+sources:
+- https://github.com/iter8-tools/iter8
+maintainers:
+- name: Srinivasan Parthasarathy
+  email: spartha@us.ibm.com
+  url: https://researcher.watson.ibm.com/researcher/view.php?person=us-spartha
+icon: https://github.com/iter8-tools/iter8/raw/master/mkdocs/docs/images/favicon.png
+dependencies:
+- name: iter8lib
+  version: 0.9.x
+  repository: file://../
+appVersion: v0.9

--- a/charts/load-test-http/templates/_experiment.tpl
+++ b/charts/load-test-http/templates/_experiment.tpl
@@ -1,0 +1,4 @@
+{{ define "experiment" -}}
+{{- include "task.http" . -}}
+{{- include "task.assess" . -}}
+{{ end }}

--- a/charts/load-test-http/templates/k8s.yaml
+++ b/charts/load-test-http/templates/k8s.yaml
@@ -1,0 +1,1 @@
+{{- include "k.manifest" . }}

--- a/charts/load-test-http/values.yaml
+++ b/charts/load-test-http/values.yaml
@@ -1,0 +1,64 @@
+### Defaults values for the load-test-http experiment chart.
+
+### The documentation follows Helm recommendations described in the URL below.
+### https://helm.sh/docs/chart_best_practices/values/#document-valuesyaml
+
+##################################
+
+### url   HTTP(S) URL where the app receives GET or POST requests.
+### This parameter is required.
+url: null
+
+### headers   HTTP headers to be used in requests sent to the app.
+### Specified as map[string]string
+headers: null
+
+### numQueries    Number of requests sent to the app. 
+numQueries: null
+
+### duration    Duration for which requests are sent to the app.
+### Value can be any Go duration string (https://pkg.go.dev/maze.io/x/duration#ParseDuration)
+### This field is ignored if `numQueries` is specified.
+duration: null
+
+### qps   Number of requests per second sent to each version.
+qps: null
+
+### connections   Number of parallel connections used to send requests.
+connections: null
+
+### payloadStr    String data to be sent as payload. 
+### If this field is specified, Iter8 will send HTTP POST requests.
+### with this string as the payload.
+### This field is ignored if `payloadURL` is specified.
+payloadStr: null
+
+### payloadUrl    URL of payload. If this field is specified, 
+### Iter8 will send HTTP POST requests to versions with 
+### data downloaded from this URL as the payload.
+payloadURL: null
+
+### contentType   The type of the payload. Indicated using the Content-Type HTTP header value. 
+### This is intended to be used in conjunction with one of the `payload*` fields above. 
+### If this field is specified, Iter8 will send HTTP POST requests to versions 
+### with this content type header value. If payload is supplied, and this field is 
+### defaulted to "application/octet-stream".
+contentType: null
+
+### errorsAbove   Any HTTP response code above this value is considered an error.
+### If left unspecified, this parameter is defaulted to 400.
+errorsAbove: null
+
+### SLOs    A map of service level objectives (SLOs) that the app needs to satisfy.
+### Metrics collected during the load test are used to verify if the app satisfies SLOs.
+### Each SLO has a key which is the metric name, 
+### and a value which is the upper limit on the metric.
+### Valid metric names are error-rate, error-count, latency-max, 
+### latency-mean, latency-stddev, and latency-pX, where X is any latency percentile 
+### (i.e., any float value between 0 and 100).
+### Unit of latency is msec.
+### Example:
+###   http/error-rate: 0
+###   http/latency-mean: 50
+###   http/latency-p99: 200
+SLOs: null


### PR DESCRIPTION
This is a step towards #1197 

Once this PR is merged, the `charts` directory will be part of the `iter8` repo, and the `iter8 hub/launch/...` and other relevant commands may be subsequently modified to work with local charts.

Signed-off-by: Srinivasan Parthasarathy <spartha@us.ibm.com>