### PR TITLE
Fix Hub and versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ INSTALL_PATH ?= /usr/local/bin
 DIST_DIRS   := find * -type d -exec
 TARGETS     := darwin/amd64 linux/amd64 linux/386 windows/amd64
 BINNAME     ?= iter8
+ITER8_IMG ?= iter8/iter8:edge
 
 GOBIN         = $(shell go env GOBIN)
 ifeq ($(GOBIN),)
@@ -82,6 +83,17 @@ dist: build-cross
 .PHONY: clean
 clean:
 	@rm -rf '$(BINDIR)' ./_dist
+
+# ------------------------------------------------------------------------------
+#	 Docker
+
+.PHONY: docker-build
+ docker-build:
+ 	docker build -f Dockerfile -t $(ITER8_IMG) .
+
+ .PHONY: docker-push
+ docker-push:
+ 	docker push $(ITER8_IMG)
 
 # ------------------------------------------------------------------------------
 #  test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ INSTALL_PATH ?= /usr/local/bin
 DIST_DIRS   := find * -type d -exec
 TARGETS     := darwin/amd64 linux/amd64 linux/386 windows/amd64
 BINNAME     ?= iter8
-ITER8_IMG ?= iter8/iter8:latest
 
 GOBIN         = $(shell go env GOBIN)
 ifeq ($(GOBIN),)
@@ -30,18 +29,12 @@ ifdef VERSION
 endif
 BINARY_VERSION ?= ${GIT_TAG}
 
-# Only set Version if building a tag or VERSION is set
+# Only set Version if GIT_TAG or VERSION is set
 ifneq ($(BINARY_VERSION),)
 	LDFLAGS += -X github.com/iter8-tools/iter8/base.Version=${BINARY_VERSION}
 endif
 
-VERSION_METADATA = unreleased
-# Clear the "unreleased" string in BuildMetadata
-ifneq ($(GIT_TAG),)
-	VERSION_METADATA=
-endif
 
-LDFLAGS += -X github.com/iter8-tools/iter8/cmd.metadata=${VERSION_METADATA}
 LDFLAGS += -X github.com/iter8-tools/iter8/cmd.gitCommit=${GIT_COMMIT}
 
 .PHONY: all
@@ -89,14 +82,6 @@ dist: build-cross
 .PHONY: clean
 clean:
 	@rm -rf '$(BINDIR)' ./_dist
-
-.PHONY: docker-build
-docker-build:
-	docker build -f Dockerfile -t $(ITER8_IMG) .
-
-.PHONY: docker-push
-docker-push:
-	docker push $(ITER8_IMG)
 
 # ------------------------------------------------------------------------------
 #  test

--- a/action/hub.go
+++ b/action/hub.go
@@ -2,13 +2,14 @@ package action
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/iter8-tools/iter8/base"
 	"github.com/iter8-tools/iter8/base/log"
 )
 
-var DefaultGitFolder = "github.com/iter8-tools/iter8.git?ref=" + base.Version + "//" + chartsFolderName
+const defaultIter8Repo = "github.com/iter8-tools/iter8.git"
 
 // HubOpts are the options used for downloading Iter8 experiment charts
 type HubOpts struct {
@@ -18,11 +19,18 @@ type HubOpts struct {
 	ChartsDir string
 }
 
+func DefaultGitFolder() string {
+	// parse version
+	v := strings.Split(base.Version, "-")
+	ref := v[0]
+	return defaultIter8Repo + "?ref=" + ref + "//" + chartsFolderName
+}
+
 // NewHubOpts initializes and returns hub opts
 func NewHubOpts() *HubOpts {
 
 	return &HubOpts{
-		GitFolder: DefaultGitFolder,
+		GitFolder: DefaultGitFolder(),
 		ChartsDir: chartsFolderName,
 	}
 }

--- a/action/launch.go
+++ b/action/launch.go
@@ -33,7 +33,7 @@ type LaunchOpts struct {
 func NewLaunchOpts(kd *driver.KubeDriver) *LaunchOpts {
 	return &LaunchOpts{
 		DryRun:          false,
-		GitFolder:       DefaultGitFolder,
+		GitFolder:       DefaultGitFolder(),
 		ChartsParentDir: ".",
 		NoDownload:      false,
 		ChartName:       "",

--- a/base/collect_grpc.go
+++ b/base/collect_grpc.go
@@ -62,15 +62,8 @@ type collectGRPCTask struct {
 
 // initializeDefaults sets default values for the collect task
 func (t *collectGRPCTask) initializeDefaults() {
-	ghzcBytes, _ := json.MarshalIndent(t.With.Config, "", "	")
-	log.Logger.WithStackTrace(string(ghzcBytes)).Trace("runner config before defaulting")
-
 	// set defaults
 	gd.SetDefaults(&t.With.Config)
-
-	ghzcBytes, _ = json.MarshalIndent(t.With.Config, "", "	")
-	log.Logger.WithStackTrace(string(ghzcBytes)).Trace("runner config after defaulting")
-
 	// if dial timeout is zero, then set a default...
 	if t.With.DialTimeout == 0 {
 		td, _ := time.ParseDuration("10s")

--- a/base/collect_grpc.go
+++ b/base/collect_grpc.go
@@ -62,8 +62,15 @@ type collectGRPCTask struct {
 
 // initializeDefaults sets default values for the collect task
 func (t *collectGRPCTask) initializeDefaults() {
+	ghzcBytes, _ := json.MarshalIndent(t.With.Config, "", "	")
+	log.Logger.WithStackTrace(string(ghzcBytes)).Trace("runner config before defaulting")
+
 	// set defaults
 	gd.SetDefaults(&t.With.Config)
+
+	ghzcBytes, _ = json.MarshalIndent(t.With.Config, "", "	")
+	log.Logger.WithStackTrace(string(ghzcBytes)).Trace("runner config after defaulting")
+
 	// if dial timeout is zero, then set a default...
 	if t.With.DialTimeout == 0 {
 		td, _ := time.ParseDuration("10s")

--- a/base/util.go
+++ b/base/util.go
@@ -11,7 +11,7 @@ var MajorMinor = "v0.10"
 
 // Version is the semantic version of Iter8 (with the `v` prefix)
 // Version is intended to be set using LDFLAGS at build time
-var Version = "v0.10.0"
+var Version = "v0.10.1"
 
 // int64Pointer takes an int64 as input, creates a new variable with the input value, and returns a pointer to the variable
 func int64Pointer(i int64) *int64 {

--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -34,7 +34,7 @@ func newHubCmd() *cobra.Command {
 
 // addGitFolderFlag
 func addGitFolderFlag(cmd *cobra.Command, gitFolderPtr *string) {
-	cmd.Flags().StringVar(gitFolderPtr, "gitFolder", ia.DefaultGitFolder, "Git folder containing iter8 charts")
+	cmd.Flags().StringVar(gitFolderPtr, "gitFolder", ia.DefaultGitFolder(), "Git folder containing iter8 charts")
 }
 
 // initialize with the hub command

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,7 +16,7 @@ Print the version of Iter8 CLI.
 
 The output may look as follows:
 
-	$ version.BuildInfo{Version:"v0.8.32", GitCommit:"fe51cd1e31e6a202cba7aliv9552a6d418ded79a", GoVersion:"go1.17.6"}
+	$ version.BuildInfo{Version:"v0.10.1", GitCommit:"fe51cd1e31e6a202cba7aliv9552a6d418ded79a", GoVersion:"go1.17.6"}
 
 In the sample output shown above:
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -26,8 +26,6 @@ In the sample output shown above:
 `
 
 var (
-	// metadata is extra build time data
-	metadata = ""
 	// gitCommit is the git sha1
 	gitCommit = ""
 )
@@ -59,7 +57,7 @@ func newVersionCmd() *cobra.Command {
 					fmt.Println()
 					return nil
 				}
-				fmt.Println(getVersion())
+				fmt.Println(base.Version)
 				return nil
 			}
 			fmt.Printf("%#v", v)
@@ -71,18 +69,10 @@ func newVersionCmd() *cobra.Command {
 	return cmd
 }
 
-// getVersion returns the semver string of the version
-func getVersion() string {
-	if metadata == "" {
-		return base.Version
-	}
-	return base.Version + "+" + metadata
-}
-
 // get returns build info
 func getBuildInfo() BuildInfo {
 	v := BuildInfo{
-		Version:   getVersion(),
+		Version:   base.Version,
 		GitCommit: gitCommit,
 		GoVersion: runtime.Version(),
 	}


### PR DESCRIPTION
1. The hub command should work even if we make local changes to code. This PR ensures this by fixing the Makefile, the hub and version commands.
2. Simplify Makefile. Metadata which used to be set earlier is now removed. We never used it up until now.