### PR TITLE
Kubernetes experiments

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -116,7 +116,6 @@ jobs:
         --set payloadURL="https://httpbin.org/stream/1"
     - name: try other iter8 k commands
       run: |
-        sleep 30
         iter8 k assert -c completed -c nofailure --timeout 60s
         iter8 k report
         iter8 k log

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -92,3 +92,32 @@ jobs:
         push: true
         build-args: |
           TAG=v${{ env.VERSION }}
+
+  kubernetes-experiment:
+    name: Kubernetes http load test    
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+    - name: Install Iter8
+      run: |
+        tagref=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        wget https://github.com/iter8-tools/iter8/releases/download/$tagref/iter8-linux-amd64.tar.gz
+        tar -xvf iter8-linux-amd64.tar.gz
+        mv linux-amd64/iter8 /usr/local/bin
+    - uses: engineerd/setup-kind@v0.5.0
+    - name: create app
+      run: |
+        kubectl create deployment httpbin --image=kennethreitz/httpbin
+        kubectl expose deployment httpbin --type=ClusterIP --port=80
+    - name: iter8 k launch
+      run: |
+        iter8 k launch -c load-test-http \
+        --set url="http://httpbin.default/get" \
+        --set payloadURL="https://httpbin.org/stream/1"
+    - name: try other iter8 k commands
+      run: |
+        sleep 30
+        iter8 k assert -c completed -c nofailure --timeout 60s
+        iter8 k report
+        iter8 k log
+        iter8 k delete

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
         done;
     - name: launch load-test-http
       run: |
-        iter8 launch -c load-test-http --chartsParentDir ../ \
+        iter8 launch -c load-test-http --noDownload \
         --set url="http://$HOST_IP/post" \
         --set payloadURL="https://httpbin.org/stream/1"
     - name: assert experiment completed without failures
@@ -78,9 +78,8 @@ jobs:
     - name: load test grpc service method
       run: |
         set -e
-        cd charts/load-test-grpc
         export LOG_LEVEL=trace
-        iter8 launch -c load-test-grpc --chartsParentDir ../ \
+        iter8 launch -c load-test-grpc --noDownload \
           --set host="127.0.0.1:50051" \
           --set call="helloworld.Greeter.SayHello" \
           --set protoURL="https://raw.githubusercontent.com/grpc/grpc-go/master/examples/helloworld/helloworld/helloworld.proto" \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,8 +99,8 @@ jobs:
           --set host="127.0.0.1:50051" \
           --set call="helloworld.Greeter.SayHello" \
           --set protoURL="https://raw.githubusercontent.com/grpc/grpc-go/master/examples/helloworld/helloworld/helloworld.proto" \
-          --set dataURL="https://gist.githubusercontent.com/sriumcp/3f3178f4b698af6696c925832e51b0ba/raw/ae3b9b1c8244c8ebb1552035967544bebdafc1d2/name.json" \
-          --set metadataURL="https://gist.githubusercontent.com/sriumcp/3f3178f4b698af6696c925832e51b0ba/raw/ae3b9b1c8244c8ebb1552035967544bebdafc1d2/name.json" \
+          --set dataURL="https://gist.githubusercontent.com/sriumcp/3f3178f4b698af6696c925832e51b0ba/raw/d02aa698d34aa2067f7a2f6afb4ceb616b0db822/name.json" \
+          --set metadataURL="https://gist.githubusercontent.com/sriumcp/3f3178f4b698af6696c925832e51b0ba/raw/d02aa698d34aa2067f7a2f6afb4ceb616b0db822/name.json" \
           --set SLOs.grpc/error-rate=0 \
           --set SLOs.grpc/latency/mean=50 \
           --set SLOs.grpc/latency/p90=100 \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -127,16 +127,18 @@ jobs:
         kubectl create deployment httpbin --image=kennethreitz/httpbin
         kubectl expose deployment httpbin --type=ClusterIP --port=80
 
-    - name: launch load-test-http
+    - name: iter8 k launch
       run: |
         iter8 k launch -c load-test-http --noDownload \
         --set url="http://httpbin.default/get" \
         --set payloadURL="https://httpbin.org/stream/1"
 
-    - name: assert experiment completed without failures
+    - name: try other iter8 k commands
       run: |
         iter8 k assert -c completed -c nofailure -t 60s
-
+        iter8 k report
+        iter8 k log
+        iter8 k delete
 
   static-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,7 +91,7 @@ jobs:
           --set SLOs.grpc/latency/p'97\.5'=200
         iter8 assert -c completed -c nofailure -c slos
         
-    - name: load test grpc service with protoURL and dataURL
+    - name: load test grpc service with proto/data/metadata URLs
       run: |
         set -e
         export LOG_LEVEL=trace
@@ -99,8 +99,8 @@ jobs:
           --set host="127.0.0.1:50051" \
           --set call="helloworld.Greeter.SayHello" \
           --set protoURL="https://raw.githubusercontent.com/grpc/grpc-go/master/examples/helloworld/helloworld/helloworld.proto" \
-          --set dataURL="https://httpbin.org/stream/1" \
-          --set data.name="frodo" \
+          --set dataURL="https://gist.githubusercontent.com/sriumcp/3f3178f4b698af6696c925832e51b0ba/raw/ae3b9b1c8244c8ebb1552035967544bebdafc1d2/name.json" \
+          --set metadataURL="https://gist.githubusercontent.com/sriumcp/3f3178f4b698af6696c925832e51b0ba/raw/ae3b9b1c8244c8ebb1552035967544bebdafc1d2/name.json" \
           --set SLOs.grpc/error-rate=0 \
           --set SLOs.grpc/latency/mean=50 \
           --set SLOs.grpc/latency/p90=100 \
@@ -135,7 +135,7 @@ jobs:
 
     - name: try other iter8 k commands
       run: |
-        iter8 k assert -c completed -c nofailure -t 60s
+        iter8 k assert -c completed -c nofailure --timeout 60s
         iter8 k report
         iter8 k log
         iter8 k delete

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,7 +75,8 @@ jobs:
         cd grpc-go/examples/helloworld
         go build greeter_server/main.go
         ./main &
-    - name: load test grpc service method
+
+    - name: load test grpc service with protoURL
       run: |
         set -e
         export LOG_LEVEL=trace
@@ -88,12 +89,22 @@ jobs:
           --set SLOs.grpc/latency/mean=50 \
           --set SLOs.grpc/latency/p90=100 \
           --set SLOs.grpc/latency/p'97\.5'=200
-        # echo "experiment ... "
-        # cat experiment.yaml
-        # iter8 run
-        # echo "report ..."
-        # iter8 report
-        # echo "assert... "
+        iter8 assert -c completed -c nofailure -c slos
+        
+    - name: load test grpc service with protoURL and dataURL
+      run: |
+        set -e
+        export LOG_LEVEL=trace
+        iter8 launch -c load-test-grpc --noDownload \
+          --set host="127.0.0.1:50051" \
+          --set call="helloworld.Greeter.SayHello" \
+          --set protoURL="https://raw.githubusercontent.com/grpc/grpc-go/master/examples/helloworld/helloworld/helloworld.proto" \
+          --set dataURL="https://httpbin.org/stream/1" \
+          --set data.name="frodo" \
+          --set SLOs.grpc/error-rate=0 \
+          --set SLOs.grpc/latency/mean=50 \
+          --set SLOs.grpc/latency/p90=100 \
+          --set SLOs.grpc/latency/p'97\.5'=200
         iter8 assert -c completed -c nofailure -c slos
 
   static-check:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,7 @@ jobs:
       run: |
         iter8 launch -c load-test-http --chartsParentDir ../ \
         --set url="http://$HOST_IP/post" \
-        --payloadURL= "https://httpbin.org/stream/1"
+        --set payloadURL= "https://httpbin.org/stream/1"
     - name: assert experiment completed without failures
       run: |
         iter8 assert -c completed -c nofailure

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,40 +107,6 @@ jobs:
           --set SLOs.grpc/latency/p'97\.5'=200
         iter8 assert -c completed -c nofailure -c slos
 
-  kubernetes-experiment:
-    name: Kubernetes http load test
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    - name: Build and install Iter8
-      run: make install
-    
-    - uses: engineerd/setup-kind@v0.5.0
-
-    - name: create app
-      run: |
-        kubectl create deployment httpbin --image=kennethreitz/httpbin
-        kubectl expose deployment httpbin --type=ClusterIP --port=80
-
-    - name: iter8 k launch
-      run: |
-        iter8 k launch -c load-test-http --noDownload \
-        --set url="http://httpbin.default/get" \
-        --set payloadURL="https://httpbin.org/stream/1"
-
-    - name: try other iter8 k commands
-      run: |
-        sleep 30
-        iter8 k assert -c completed -c nofailure --timeout 60s
-        iter8 k report
-        iter8 k log
-        iter8 k delete
-
   static-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,47 +27,6 @@ jobs:
         fi
 
   load-test-http:
-    - name: load test GET endpoint
-      run: | 
-        cat << EOF > experiment-config.yaml
-          url: http://$HOST_IP/get
-        EOF
-    - uses: iter8-tools/iter8-action@v1
-      with:
-        chart: load-test-http
-        valuesFile: experiment-config.yaml
-
-    - name: load test GET endpoint
-      run: | 
-        cat << EOF > experiment-config.yaml
-          url: http://$HOST_IP/get
-          SLOs:
-            http/latency-p25: 80
-            http/latency-p50: 100
-            http/latency-p95.0: 200
-        EOF
-    - uses: iter8-tools/iter8-action@v1
-      with:
-        chart: load-test-http
-        valuesFile: experiment-config.yaml
-
-    - name: load test POST endpoint
-      run: | 
-        cat << EOF > experiment-config.yaml
-          url: http://$HOST_IP/post
-          payloadURL: https://cdn.pixabay.com/photo/2021/09/08/17/58/poppy-6607526_1280.jpg
-          contentType: "image/jpeg"
-          SLOs:
-            http/latency-p25: 80
-            http/latency-p50: 100
-            http/latency-p95.0: 200
-        EOF
-    - uses: iter8-tools/iter8-action@v1
-      with:
-        chart: load-test-http
-        valuesFile: experiment-config.yaml
-
-  load-test-http:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -91,7 +50,7 @@ jobs:
     - name: launch load-test-http
       run: |
         iter8 launch -c load-test-http --chartsParentDir ../ \
-        --set url="http://$HOST_IP/get" \
+        --set url="http://$HOST_IP/post" \
         --payloadURL= "https://httpbin.org/stream/1"
     - name: assert experiment completed without failures
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,77 @@ jobs:
           exit 1
         fi
 
+  load-test-http:
+    - name: load test GET endpoint
+      run: | 
+        cat << EOF > experiment-config.yaml
+          url: http://$HOST_IP/get
+        EOF
+    - uses: iter8-tools/iter8-action@v1
+      with:
+        chart: load-test-http
+        valuesFile: experiment-config.yaml
+
+    - name: load test GET endpoint
+      run: | 
+        cat << EOF > experiment-config.yaml
+          url: http://$HOST_IP/get
+          SLOs:
+            http/latency-p25: 80
+            http/latency-p50: 100
+            http/latency-p95.0: 200
+        EOF
+    - uses: iter8-tools/iter8-action@v1
+      with:
+        chart: load-test-http
+        valuesFile: experiment-config.yaml
+
+    - name: load test POST endpoint
+      run: | 
+        cat << EOF > experiment-config.yaml
+          url: http://$HOST_IP/post
+          payloadURL: https://cdn.pixabay.com/photo/2021/09/08/17/58/poppy-6607526_1280.jpg
+          contentType: "image/jpeg"
+          SLOs:
+            http/latency-p25: 80
+            http/latency-p50: 100
+            http/latency-p95.0: 200
+        EOF
+    - uses: iter8-tools/iter8-action@v1
+      with:
+        chart: load-test-http
+        valuesFile: experiment-config.yaml
+
+  load-test-http:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Build and install Iter8
+      run: make install
+    - name: run httpbin
+      run: |
+        set -e
+        docker pull kennethreitz/httpbin
+        docker run -p 80:80 kennethreitz/httpbin &
+        HOST_IP=$(ip -f inet addr show docker0 | grep -Po 'inet \K[\d.]+')
+        echo "HOST_IP=$HOST_IP" >> $GITHUB_ENV
+        while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://$HOST_IP/get)" != "200" ]]; do
+          sleep 5; 
+        done;
+    - name: launch load-test-http
+      run: |
+        iter8 launch -c load-test-http --chartsParentDir ../ \
+        --set url="http://$HOST_IP/get" \
+        --payloadURL= "https://httpbin.org/stream/1"
+    - name: assert experiment completed without failures
+      run: |
+        iter8 assert -c completed -c nofailure
+
   static-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,7 @@ jobs:
         fi
 
   load-test-http:
+    name: http load test with payloadURL
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
@@ -55,6 +56,46 @@ jobs:
     - name: assert experiment completed without failures
       run: |
         iter8 assert -c completed -c nofailure
+
+  load-test-grpc:
+    name: gRPC load test with various URLs
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Build and install Iter8
+      run: make install
+    - name: run greeter
+      run: |
+        git clone -b v1.43.0 https://github.com/grpc/grpc-go
+        cd grpc-go/examples/helloworld
+        go build greeter_server/main.go
+        ./main &
+    - name: load test grpc service method
+      run: |
+        set -e
+        cd charts/load-test-grpc
+        export LOG_LEVEL=trace
+        iter8 launch -c load-test-http --chartsParentDir ../ \
+          --set host="127.0.0.1:50051" \
+          --set call="helloworld.Greeter.SayHello" \
+          --set protoURL="https://raw.githubusercontent.com/grpc/grpc-go/master/examples/helloworld/helloworld/helloworld.proto" \
+          --set data.name="frodo" \
+          --set SLOs.grpc/error-rate=0 \
+          --set SLOs.grpc/latency/mean=50 \
+          --set SLOs.grpc/latency/p90=100 \
+          --set SLOs.grpc/latency/p'97\.5'=200
+        # echo "experiment ... "
+        # cat experiment.yaml
+        # iter8 run
+        # echo "report ..."
+        # iter8 report
+        # echo "assert... "
+        iter8 assert -c completed -c nofailure -c slos
 
   static-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,6 +107,37 @@ jobs:
           --set SLOs.grpc/latency/p'97\.5'=200
         iter8 assert -c completed -c nofailure -c slos
 
+  kubernetes-experiment:
+    name: Kubernetes http load test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Build and install Iter8
+      run: make install
+    
+    - uses: engineerd/setup-kind@v0.5.0
+
+    - name: create app
+      run: |
+        kubectl create deployment httpbin --image=kennethreitz/httpbin
+        kubectl expose deployment httpbin --type=ClusterIP --port=80
+
+    - name: launch load-test-http
+      run: |
+        iter8 k launch -c load-test-http --noDownload \
+        --set url="http://httpbin.default/get" \
+        --set payloadURL="https://httpbin.org/stream/1"
+
+    - name: assert experiment completed without failures
+      run: |
+        iter8 k assert -c completed -c nofailure -t 60s
+
+
   static-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -135,6 +135,7 @@ jobs:
 
     - name: try other iter8 k commands
       run: |
+        sleep 30
         iter8 k assert -c completed -c nofailure --timeout 60s
         iter8 k report
         iter8 k log

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,7 +80,7 @@ jobs:
         set -e
         cd charts/load-test-grpc
         export LOG_LEVEL=trace
-        iter8 launch -c load-test-http --chartsParentDir ../ \
+        iter8 launch -c load-test-grpc --chartsParentDir ../ \
           --set host="127.0.0.1:50051" \
           --set call="helloworld.Greeter.SayHello" \
           --set protoURL="https://raw.githubusercontent.com/grpc/grpc-go/master/examples/helloworld/helloworld/helloworld.proto" \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,7 +52,7 @@ jobs:
       run: |
         iter8 launch -c load-test-http --chartsParentDir ../ \
         --set url="http://$HOST_IP/post" \
-        --set payloadURL= "https://httpbin.org/stream/1"
+        --set payloadURL="https://httpbin.org/stream/1"
     - name: assert experiment completed without failures
       run: |
         iter8 assert -c completed -c nofailure

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ iter8
 # iter8lib tgz
 iter8lib*.tgz
 
+# data
+payload.dat
+

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 BINDIR      := $(CURDIR)/bin
-INSTALL_PATH ?= /usr/local/bin
+INSTALL_PATH		?= /usr/local/bin
 DIST_DIRS   := find * -type d -exec
 TARGETS     := darwin/amd64 linux/amd64 linux/386 windows/amd64
 BINNAME     ?= iter8
-ITER8_IMG ?= iter8/iter8:edge
+
+# Adding a colon followed by a tag for ITER8_IMG causes problems in the rest of the makefile
+# export ITER8_IMG as an env variable before invoking make docker-build/push
+# For example, export ITER8_IMG=iter8/iter8:edge
+
+ITER8_IMG		?= iter8/iter8#:edge
 
 GOBIN         = $(shell go env GOBIN)
 ifeq ($(GOBIN),)
@@ -26,15 +31,14 @@ GIT_COMMIT = $(shell git rev-parse HEAD)
 GIT_TAG    = $(shell git describe --tags --dirty)
 
 ifdef VERSION
-	BINARY_VERSION = $(VERSION)
+	BINARY_VERSION	=$(VERSION)
 endif
-BINARY_VERSION ?= ${GIT_TAG}
+BINARY_VERSION	?=${GIT_TAG}
 
 # Only set Version if GIT_TAG or VERSION is set
 ifneq ($(BINARY_VERSION),)
 	LDFLAGS += -X github.com/iter8-tools/iter8/base.Version=${BINARY_VERSION}
 endif
-
 
 LDFLAGS += -X github.com/iter8-tools/iter8/cmd.gitCommit=${GIT_COMMIT}
 
@@ -88,12 +92,12 @@ clean:
 #	 Docker
 
 .PHONY: docker-build
- docker-build:
- 	docker build -f Dockerfile -t $(ITER8_IMG) .
+docker-build:
+	docker build -f Dockerfile -t $(ITER8_IMG) .
 
- .PHONY: docker-push
- docker-push:
- 	docker push $(ITER8_IMG)
+.PHONY: docker-push
+docker-push: docker-build
+	docker push $(ITER8_IMG)
 
 # ------------------------------------------------------------------------------
 #  test

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,8 @@
 BINDIR      := $(CURDIR)/bin
-INSTALL_PATH		?= /usr/local/bin
+INSTALL_PATH ?= /usr/local/bin
 DIST_DIRS   := find * -type d -exec
 TARGETS     := darwin/amd64 linux/amd64 linux/386 windows/amd64
 BINNAME     ?= iter8
-
-# Adding a colon followed by a tag for ITER8_IMG causes problems in the rest of the makefile
-# export ITER8_IMG as an env variable before invoking make docker-build/push
-# For example, export ITER8_IMG=iter8/iter8:edge
-
-ITER8_IMG		?= iter8/iter8#:edge
 
 GOBIN         = $(shell go env GOBIN)
 ifeq ($(GOBIN),)
@@ -31,14 +25,15 @@ GIT_COMMIT = $(shell git rev-parse HEAD)
 GIT_TAG    = $(shell git describe --tags --dirty)
 
 ifdef VERSION
-	BINARY_VERSION	=$(VERSION)
+	BINARY_VERSION = $(VERSION)
 endif
-BINARY_VERSION	?=${GIT_TAG}
+BINARY_VERSION ?= ${GIT_TAG}
 
 # Only set Version if GIT_TAG or VERSION is set
 ifneq ($(BINARY_VERSION),)
 	LDFLAGS += -X github.com/iter8-tools/iter8/base.Version=${BINARY_VERSION}
 endif
+
 
 LDFLAGS += -X github.com/iter8-tools/iter8/cmd.gitCommit=${GIT_COMMIT}
 
@@ -87,17 +82,6 @@ dist: build-cross
 .PHONY: clean
 clean:
 	@rm -rf '$(BINDIR)' ./_dist
-
-# ------------------------------------------------------------------------------
-#	 Docker
-
-.PHONY: docker-build
-docker-build:
-	docker build -f Dockerfile -t $(ITER8_IMG) .
-
-.PHONY: docker-push
-docker-push: docker-build
-	docker push $(ITER8_IMG)
 
 # ------------------------------------------------------------------------------
 #  test

--- a/action/gen_test.go
+++ b/action/gen_test.go
@@ -44,5 +44,4 @@ func TestGenGRPC(t *testing.T) {
 	m = m["with"].(map[string]interface{})
 	s := m["proto"].(string)
 	assert.Equal(t, "helloworld.proto", s)
-
 }

--- a/base/collect_grpc.go
+++ b/base/collect_grpc.go
@@ -9,12 +9,6 @@ import (
 	gd "github.com/mcuadros/go-defaults"
 )
 
-// // collectGRPCInputs holds all the inputs for this task
-// type collectGRPCInputs struct {
-// 	// Config is the ghz runner.Config object embedded in the input
-// 	runner.Config
-// }
-
 const (
 	// CollectGRPCTaskName is the name of this task which performs load generation and metrics collection for gRPC services.
 	CollectGRPCTaskName = "gen-load-and-collect-metrics-grpc"

--- a/base/collect_http_test.go
+++ b/base/collect_http_test.go
@@ -25,10 +25,8 @@ func TestRunCollectHTTP(t *testing.T) {
 		With: collectHTTPInputs{
 			Duration:    StringPointer("1s"),
 			PayloadFile: StringPointer(CompletePath("../", "testdata/payload/ukpolice.json")),
-			VersionInfo: []*versionHTTP{{
-				Headers: map[string]string{},
-				URL:     "https://something.com",
-			}},
+			Headers:     map[string]string{},
+			URL:         "https://something.com",
 		},
 	}
 

--- a/base/experiment_test.go
+++ b/base/experiment_test.go
@@ -33,8 +33,9 @@ func TestRunTask(t *testing.T) {
 			Task: StringPointer(CollectHTTPTaskName),
 		},
 		With: collectHTTPInputs{
-			Duration:    StringPointer("1s"),
-			VersionInfo: []*versionHTTP{{Headers: map[string]string{}, URL: "https://httpbin.org/get"}},
+			Duration: StringPointer("1s"),
+			Headers:  map[string]string{},
+			URL:      "https://httpbin.org/get",
 		},
 	}
 

--- a/base/mock_qs_test.go
+++ b/base/mock_qs_test.go
@@ -20,10 +20,8 @@ func TestMockQuickStartWithSLOs(t *testing.T) {
 		},
 		With: collectHTTPInputs{
 			Duration: StringPointer("2s"),
-			VersionInfo: []*versionHTTP{{
-				Headers: map[string]string{},
-				URL:     testURL,
-			}},
+			Headers:  map[string]string{},
+			URL:      testURL,
 		},
 	}
 
@@ -68,10 +66,8 @@ func TestMockQuickStartWithSLOsAndPercentiles(t *testing.T) {
 		},
 		With: collectHTTPInputs{
 			Duration: StringPointer("1s"),
-			VersionInfo: []*versionHTTP{{
-				Headers: map[string]string{},
-				URL:     testURL,
-			}},
+			Headers:  map[string]string{},
+			URL:      testURL,
 		},
 	}
 

--- a/base/util.go
+++ b/base/util.go
@@ -11,7 +11,7 @@ var MajorMinor = "v0.10"
 
 // Version is the semantic version of Iter8 (with the `v` prefix)
 // Version is intended to be set using LDFLAGS at build time
-var Version = "v0.10.1"
+var Version = "v0.10.3"
 
 // int64Pointer takes an int64 as input, creates a new variable with the input value, and returns a pointer to the variable
 func int64Pointer(i int64) *int64 {

--- a/charts/iter8lib/Chart.yaml
+++ b/charts/iter8lib/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: iter8lib
-version: 0.9.1
+version: 0.9.2
 description: Iter8 library chart
 type: library
 home: https://iter8.tools

--- a/charts/iter8lib/Chart.yaml
+++ b/charts/iter8lib/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: iter8lib
-version: 0.9.2
+version: 0.10.0
 description: Iter8 library chart
 type: library
 home: https://iter8.tools
@@ -11,4 +11,4 @@ maintainers:
   email: spartha@us.ibm.com
   url: https://researcher.watson.ibm.com/researcher/view.php?person=us-spartha
 icon: https://github.com/iter8-tools/iter8/raw/master/mkdocs/docs/images/favicon.png
-appVersion: v0.9
+appVersion: v0.10

--- a/charts/iter8lib/Chart.yaml
+++ b/charts/iter8lib/Chart.yaml
@@ -11,4 +11,3 @@ maintainers:
   email: spartha@us.ibm.com
   url: https://researcher.watson.ibm.com/researcher/view.php?person=us-spartha
 icon: https://github.com/iter8-tools/iter8/raw/master/mkdocs/docs/images/favicon.png
-appVersion: v0.10

--- a/charts/iter8lib/README.md
+++ b/charts/iter8lib/README.md
@@ -1,18 +1,3 @@
 # Iter8 library chart
 
 > This chart provides reusable templates that are used by Iter8 experiment charts. Experiments can be composed by using this chart as a dependency, and by including templates available in this library chart.
-
-**Templates for Iter8 tasks:** 
-
-- `task.http`: The `gen-load-and-collect-metrics-http` task
-- `task.grpc`: The `gen-load-and-collect-metrics-grpc` task
-- `task.assess`: The `assess-app-versions` task
-
-**Templates for Kubernetes experiments:**
-
-- `k.job`: Kubernetes experiment job
-- `k.spec.secret`: Kubernetes secret containing experiment spec
-- `k.spec.role`: Role for Kubernetes spec secret
-- `k.spec.rolebinding`: Role binding for Kubernetes spec secret
-- `k.result.role`: Role for Kubernetes result secret
-- `k.result.rolebinding`: Role binding for Kubernetes result secret

--- a/charts/iter8lib/templates/_k-job.tpl
+++ b/charts/iter8lib/templates/_k-job.tpl
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: iter8
-        image: iter8-tools/iter8:{{  trimPrefix "v" .Chart.AppVersion }}
+        image: {{  .Values.iter8lib.global.iter8Image }}
         imagePullPolicy: Always
         command:
         - "/bin/sh"

--- a/charts/iter8lib/templates/_k-result-role.tpl
+++ b/charts/iter8lib/templates/_k-result-role.tpl
@@ -9,8 +9,8 @@ rules:
   resources: ["secrets"]
   resourceNames: ["{{ $name }}-result"]
   verbs: ["create", "get", "update"]
-- apiGroups: [""]
-  resources: ["secrets"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
   resourceNames: ["{{ $name }}-job"]
   verbs: ["get"]
 {{- end }}

--- a/charts/iter8lib/templates/_k-result-role.tpl
+++ b/charts/iter8lib/templates/_k-result-role.tpl
@@ -9,8 +9,4 @@ rules:
   resources: ["secrets"]
   resourceNames: ["{{ $name }}-result"]
   verbs: ["create", "get", "update"]
-- apiGroups: ["batch"]
-  resources: ["jobs"]
-  resourceNames: ["{{ $name }}-job"]
-  verbs: ["get"]
 {{- end }}

--- a/charts/iter8lib/templates/_k-result-role.tpl
+++ b/charts/iter8lib/templates/_k-result-role.tpl
@@ -9,4 +9,8 @@ rules:
   resources: ["secrets"]
   resourceNames: ["{{ $name }}-result"]
   verbs: ["create", "get", "update"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["{{ $name }}-job"]
+  verbs: ["get"]
 {{- end }}

--- a/charts/iter8lib/templates/_task-grpc.tpl
+++ b/charts/iter8lib/templates/_task-grpc.tpl
@@ -40,6 +40,6 @@
 # task: generate gRPC requests for app
 # collect Iter8's built-in gRPC latency and error-related metrics
 - task: gen-load-and-collect-metrics-grpc
-with:
+  with:
 {{ toYaml $vals | indent 4 }}
 {{- end }}

--- a/charts/iter8lib/templates/_task-grpc.tpl
+++ b/charts/iter8lib/templates/_task-grpc.tpl
@@ -1,12 +1,12 @@
 {{- define "task.grpc" -}}
-{{- /* Validate values */ -}}
+{{/* Validate values */}}
 {{- if not .Values.host }}
 {{- fail "Please set a value for the host parameter." }}
 {{- end }}
 {{- if not .Values.call }}
 {{- fail "Please set a value for the call parameter." }}
 {{- end }}
-{{- /* Perform the various setup steps before the main task */ -}}
+{{/* Perform the various setup steps before the main task */}}
 {{- $vals := mustDeepCopy .Values }}
 {{- if .Values.protoURL }}
 # task: download proto file from URL
@@ -36,7 +36,7 @@
 {{- $pf := dict "metadata-file" "metadata.json" }}
 {{- $vals = mustMerge $pf $vals }}
 {{- end }}
-{{- /* Write the main task */ -}}
+{{/* Write the main task */}}
 # task: generate gRPC requests for app
 # collect Iter8's built-in gRPC latency and error-related metrics
 - task: gen-load-and-collect-metrics-grpc

--- a/charts/iter8lib/templates/_task-grpc.tpl
+++ b/charts/iter8lib/templates/_task-grpc.tpl
@@ -1,7 +1,45 @@
 {{- define "task.grpc" -}}
-# task: generate gRPC requests for the given gRPC method
+{{- /* Validate values */ -}}
+{{- if not .Values.host }}
+{{- fail "Please set a value for the host parameter." }}
+{{- end }}
+{{- if not .Values.call }}
+{{- fail "Please set a value for the call parameter." }}
+{{- end }}
+{{- /* Perform the various setup steps before the main task */ -}}
+{{- $vals := mustDeepCopy .Values }}
+{{- if .Values.protoURL }}
+# task: download proto file from URL
+- run: |
+    curl -o ghz.proto {{ $vals.protoURL }}
+{{- $pf := dict "proto" "ghz.proto" }}
+{{- $vals = mustMerge $pf .Values }}
+{{- end }}
+{{- if .Values.dataURL }}
+# task: download JSON data file from URL
+- run: |
+    curl -o data.json {{ $vals.dataURL }}
+{{- $pf := dict "data-file" "data.json" }}
+{{- $vals = mustMerge $pf $vals }}
+{{- end }}
+{{- if .Values.binaryDataURL }}
+# task: download binary data file from URL
+- run: |
+    curl -o data.bin {{ $vals.binaryDataURL }}
+{{- $pf := dict "binary-file" "data.bin" }}
+{{- $vals = mustMerge $pf $vals }}
+{{- end }}
+{{- if .Values.metadataURL }}
+# task: download metadata JSON file from URL
+- run: |
+    curl -o metadata.json {{ $vals.metadataURL }}
+{{- $pf := dict "metadata-file" "metadata.json" }}
+{{- $vals = mustMerge $pf $vals }}
+{{- end }}
+{{- /* Write the main task */ -}}
+# task: generate gRPC requests for app
 # collect Iter8's built-in gRPC latency and error-related metrics
 - task: gen-load-and-collect-metrics-grpc
-  with:
-{{ toYaml .Values | indent 4 }}
-{{- end }}    
+with:
+{{ toYaml $vals | indent 4 }}
+{{- end }}

--- a/charts/iter8lib/templates/_task-http.tpl
+++ b/charts/iter8lib/templates/_task-http.tpl
@@ -1,55 +1,22 @@
 {{- define "task.http" -}}
-# task: generate HTTP requests for application URL
+{{- /* Validate values */ -}}
+{{- if not .Values.url }}
+{{- fail "Please set a value for the url parameter." }}
+{{- end }}
+{{- /* Perform the various setup steps before the main task */ -}}
+{{- $vals := mustDeepCopy .Values }}
+{{- if .Values.payloadURL }}
+# task: download payload from payload URL
+- run: |
+    curl -o payload.dat {{ $vals.payloadURL }}
+{{- $pf := dict "payloadFile" "payload.dat" }}
+{{- $vals = mustMerge $pf .Values }}
+{{- end }}
+{{- /* Write the main task */ -}}
+# task: generate HTTP requests for app
 # collect Iter8's built-in HTTP latency and error-related metrics
 - task: gen-load-and-collect-metrics-http
   with:
-
-    {{- if .Values.numQueries }}
-    numRequests: {{ .Values.numQueries | int }}
-    {{- end }}
-
-    {{- if .Values.duration }}
-    duration: {{ .Values.duration | toString }}
-    {{- end }}
-
-    {{- if .Values.qps }}
-    qps: {{ .Values.qps | float64 }}
-    {{- end }}
-
-    {{- if .Values.connections }}
-    connections: {{ .Values.connections | int }}
-    {{- end }}
-
-    {{- if .Values.payloadStr }}
-    payloadStr: {{ .Values.payloadStr | quote }}
-    {{- end }}
-
-    {{- if .Values.contentType }}
-    contentType: {{ .Values.contentType | quote }}
-    {{- end }}
-
-    {{- if .Values.errorsAbove }}
-    errorRanges:
-    - lower: {{ .Values.errorsAbove | int }}
-    {{- end }}
-
-    {{- $percentiles := list }}
-    {{- range $key, $value := .Values.SLOs }}
-    {{- if (regexMatch "http/latency-p\\d+(?:\\.\\d)?$" $key) }}
-    {{- $percentiles = append $percentiles (trimPrefix "http/latency-p" $key | float64 ) }}
-    {{- end }}
-    {{- end }}
-    {{- if $percentiles }}
-    percentiles:
-{{ toYaml ($percentiles | uniq) | indent 4 }}
-    {{- end }}
-
-    {{- ""}}
-    versionInfo:
-    - url: {{ required "A valid url value is required!" .Values.url | toString }}
-    {{- if .Values.headers }}
-      headers:
-{{ toYaml .Values.headers | indent 8 }}
-    {{- end }}
-{{- end }}    
+{{ toYaml $vals | indent 4 }}
+{{- end }}
 

--- a/charts/iter8lib/templates/_task-http.tpl
+++ b/charts/iter8lib/templates/_task-http.tpl
@@ -1,9 +1,9 @@
 {{- define "task.http" -}}
-{{- /* Validate values */ -}}
+{{/* Validate values */}}
 {{- if not .Values.url }}
 {{- fail "Please set a value for the url parameter." }}
 {{- end }}
-{{- /* Perform the various setup steps before the main task */ -}}
+{{/* Perform the various setup steps before the main task */}}
 {{- $vals := mustDeepCopy .Values }}
 {{- if .Values.payloadURL }}
 # task: download payload from payload URL
@@ -12,7 +12,7 @@
 {{- $pf := dict "payloadFile" "payload.dat" }}
 {{- $vals = mustMerge $pf .Values }}
 {{- end }}
-{{- /* Write the main task */ -}}
+{{/* Write the main task */}}
 # task: generate HTTP requests for app
 # collect Iter8's built-in HTTP latency and error-related metrics
 - task: gen-load-and-collect-metrics-http

--- a/charts/iter8lib/values.yaml
+++ b/charts/iter8lib/values.yaml
@@ -1,0 +1,2 @@
+global:
+  iter8Image: iter8/iter8:0.10

--- a/charts/load-test-grpc/Chart.yaml
+++ b/charts/load-test-grpc/Chart.yaml
@@ -24,4 +24,3 @@ dependencies:
 - name: iter8lib
   version: 0.10.x
   repository: file://../iter8lib
-appVersion: v0.10

--- a/charts/load-test-grpc/Chart.yaml
+++ b/charts/load-test-grpc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: load-test-grpc
-version: 0.9.2
+version: 0.10.0
 description: Load test, benchmark, and validate gRPC services
 type: application
 keywords:
@@ -22,6 +22,6 @@ maintainers:
 icon: https://github.com/iter8-tools/iter8/raw/master/mkdocs/docs/images/favicon.png
 dependencies:
 - name: iter8lib
-  version: 0.9.x
+  version: 0.10.x
   repository: file://../iter8lib
-appVersion: v0.9
+appVersion: v0.10

--- a/charts/load-test-http/Chart.yaml
+++ b/charts/load-test-http/Chart.yaml
@@ -24,4 +24,3 @@ dependencies:
 - name: iter8lib
   version: 0.10.x
   repository: file://../iter8lib
-appVersion: v0.10

--- a/charts/load-test-http/Chart.yaml
+++ b/charts/load-test-http/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: load-test-http
-version: 0.9.1
+version: 0.10.0
 description: Load test, benchmark, and validate HTTP services
 type: application
 keywords:
@@ -22,6 +22,6 @@ maintainers:
 icon: https://github.com/iter8-tools/iter8/raw/master/mkdocs/docs/images/favicon.png
 dependencies:
 - name: iter8lib
-  version: 0.9.x
+  version: 0.10.x
   repository: file://../iter8lib
-appVersion: v0.9
+appVersion: v0.10

--- a/charts/load-test-http/values.yaml
+++ b/charts/load-test-http/values.yaml
@@ -7,47 +7,47 @@
 
 ### url   HTTP(S) URL where the app receives GET or POST requests.
 ### This parameter is required.
-url: null
+# url: null
 
 ### headers   HTTP headers to be used in requests sent to the app.
 ### Specified as map[string]string
-headers: null
+# headers: null
 
 ### numQueries    Number of requests sent to the app. 
-numQueries: null
+# numQueries: null
 
 ### duration    Duration for which requests are sent to the app.
 ### Value can be any Go duration string (https://pkg.go.dev/maze.io/x/duration#ParseDuration)
 ### This field is ignored if `numQueries` is specified.
-duration: null
+# duration: null
 
 ### qps   Number of requests per second sent to each version.
-qps: null
+# qps: null
 
 ### connections   Number of parallel connections used to send requests.
-connections: null
+# connections: null
 
 ### payloadStr    String data to be sent as payload. 
 ### If this field is specified, Iter8 will send HTTP POST requests.
 ### with this string as the payload.
 ### This field is ignored if `payloadURL` is specified.
-payloadStr: null
+# payloadStr: null
 
 ### payloadUrl    URL of payload. If this field is specified, 
 ### Iter8 will send HTTP POST requests to versions with 
 ### data downloaded from this URL as the payload.
-payloadURL: null
+# payloadURL: null
 
 ### contentType   The type of the payload. Indicated using the Content-Type HTTP header value. 
 ### This is intended to be used in conjunction with one of the `payload*` fields above. 
 ### If this field is specified, Iter8 will send HTTP POST requests to versions 
 ### with this content type header value. If payload is supplied, and this field is 
 ### defaulted to "application/octet-stream".
-contentType: null
+# contentType: null
 
 ### errorsAbove   Any HTTP response code above this value is considered an error.
 ### If left unspecified, this parameter is defaulted to 400.
-errorsAbove: null
+# errorsAbove: null
 
 ### SLOs    A map of service level objectives (SLOs) that the app needs to satisfy.
 ### Metrics collected during the load test are used to verify if the app satisfies SLOs.
@@ -61,4 +61,4 @@ errorsAbove: null
 ###   http/error-rate: 0
 ###   http/latency-mean: 50
 ###   http/latency-p99: 200
-SLOs: null
+# SLOs: null

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -12,7 +12,7 @@ Generate an experiment.yaml file by combining an experiment chart with values.
 
     $ iter8 gen --sourceDir /path/to/load-test-http --set url=https://httpbin.org/get
 
-This command is intended for development and testing of experiment charts. For production usage, the launch subcommand is recommended.
+This command is intended for development and testing of experiment charts. For production usage, the launch command is recommended.
 `
 
 // newGenCmd creates the gen command
@@ -36,12 +36,12 @@ func newGenCmd() *cobra.Command {
 
 // addChartsParentDirFlag to the command
 func addChartsParentDirFlag(cmd *cobra.Command, chartsParentDirPtr *string) {
-	cmd.Flags().StringVar(chartsParentDirPtr, "chartsParentDir", ".", "path to experiment chart directory")
+	cmd.Flags().StringVar(chartsParentDirPtr, "chartsParentDir", ".", "directory under which the charts folder is located")
 }
 
 // addChartNameFlag to the command
 func addChartNameFlag(cmd *cobra.Command, chartNamePtr *string) {
-	cmd.Flags().StringVarP(chartNamePtr, "chartName", "c", "", "path to experiment chart directory")
+	cmd.Flags().StringVarP(chartNamePtr, "chartName", "c", "", "name of the experiment chart")
 	cmd.MarkFlagRequired("chartName")
 }
 

--- a/driver/kubedriver.go
+++ b/driver/kubedriver.go
@@ -246,14 +246,15 @@ func (driver *KubeDriver) formResultSecret(r *base.ExperimentResult) (*corev1.Se
 		return nil, err
 	}
 	// got spec secret ...
+	log.Logger.Trace("spec secret typemeta", spec.TypeMeta)
 
 	byteArray, _ := yaml.Marshal(r)
 	sec := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: driver.getResultSecretName(),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: spec.APIVersion,
-				Kind:       spec.Kind,
+				APIVersion: "v1",
+				Kind:       "secret",
 				Name:       spec.Name,
 				UID:        spec.UID,
 			}},
@@ -271,11 +272,11 @@ func (driver *KubeDriver) createExperimentResultSecret(r *base.ExperimentResult)
 		log.Logger.Trace("result secret formed")
 		secretsClient := driver.Clientset.CoreV1().Secrets(driver.Namespace())
 		log.Logger.Trace("creating result secret using client and sec", secretsClient, sec)
-		_, e := secretsClient.Create(context.Background(), sec, metav1.CreateOptions{})
+		_, err2 := secretsClient.Create(context.Background(), sec, metav1.CreateOptions{})
 		log.Logger.Trace("create result secret returned")
-		if e != nil {
+		if err2 != nil {
 			e := errors.New("unable to create result secret")
-			log.Logger.WithStackTrace(err.Error()).Error(e)
+			log.Logger.WithStackTrace(err2.Error()).Error(e)
 			return e
 		} else {
 			return nil

--- a/driver/kubedriver.go
+++ b/driver/kubedriver.go
@@ -292,13 +292,13 @@ func (driver *KubeDriver) formResultSecret(r *base.ExperimentResult) (*corev1.Se
 
 // createExperimentResultSecret creates the experiment result secret
 func (driver *KubeDriver) createExperimentResultSecret(r *base.ExperimentResult) error {
-	log.Logger.Info("forming result secret...")
+	log.Logger.Trace("forming result secret...")
 	if sec, err := driver.formResultSecret(r); err == nil {
-		log.Logger.Info("result secret formed")
+		log.Logger.Trace("result secret formed")
 		secretsClient := driver.Clientset.CoreV1().Secrets(driver.Namespace())
-		log.Logger.Info("creating result secret")
+		log.Logger.Trace("creating result secret using client and sec", secretsClient, sec)
 		_, e := secretsClient.Create(context.Background(), sec, metav1.CreateOptions{})
-		log.Logger.Info("create result secret returned")
+		log.Logger.Trace("create result secret returned")
 		if e != nil {
 			e := errors.New("unable to create result secret")
 			log.Logger.WithStackTrace(err.Error()).Error(e)

--- a/driver/kubedriver.go
+++ b/driver/kubedriver.go
@@ -292,9 +292,13 @@ func (driver *KubeDriver) formResultSecret(r *base.ExperimentResult) (*corev1.Se
 
 // createExperimentResultSecret creates the experiment result secret
 func (driver *KubeDriver) createExperimentResultSecret(r *base.ExperimentResult) error {
+	log.Logger.Info("forming result secret...")
 	if sec, err := driver.formResultSecret(r); err == nil {
+		log.Logger.Info("result secret formed")
 		secretsClient := driver.Clientset.CoreV1().Secrets(driver.Namespace())
+		log.Logger.Info("creating result secret")
 		_, e := secretsClient.Create(context.Background(), sec, metav1.CreateOptions{})
+		log.Logger.Info("create result secret returned")
 		if e != nil {
 			e := errors.New("unable to create result secret")
 			log.Logger.WithStackTrace(err.Error()).Error(e)

--- a/driver/kubedriver.go
+++ b/driver/kubedriver.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -186,26 +185,6 @@ func (driver *KubeDriver) getSecretWithRetry(name string) (s *corev1.Secret, err
 	return nil, e
 }
 
-// getJobWithRetry attempts to get a Kubernetes job with retry
-func (driver *KubeDriver) getJobWithRetry(name string) (*batchv1.Job, error) {
-
-	jobsClient := driver.Clientset.BatchV1().Jobs(driver.Namespace())
-
-	for i := 0; i < maxGetRetries; i++ {
-		j, err := jobsClient.Get(context.Background(), name, metav1.GetOptions{})
-		if err == nil {
-			return j, err
-		}
-		if !k8serrors.IsNotFound(err) {
-			log.Logger.Warningf("unable to get job: %s; %s\n", name, err.Error())
-		}
-		time.Sleep(getRetryInterval)
-	}
-	e := fmt.Errorf("unable to get job %v", name)
-	log.Logger.Error(e)
-	return nil, e
-}
-
 // getExperimentSpecSecret gets the Kubernetes experiment spec secret
 func (driver *KubeDriver) getExperimentSpecSecret() (s *corev1.Secret, err error) {
 	return driver.getSecretWithRetry(driver.getSpecSecretName())
@@ -214,11 +193,6 @@ func (driver *KubeDriver) getExperimentSpecSecret() (s *corev1.Secret, err error
 // getExperimentResultSecret gets the Kubernetes experiment result secret
 func (driver *KubeDriver) getExperimentResultSecret() (s *corev1.Secret, err error) {
 	return driver.getSecretWithRetry(driver.getResultSecretName())
-}
-
-// getExperimentJob gets the Kubernetes experiment job
-func (driver *KubeDriver) getExperimentJob() (j *batchv1.Job, err error) {
-	return driver.getJobWithRetry(driver.getExperimentJobName())
 }
 
 // ReadSpec creates an ExperimentSpec struct for a Kubernetes experiment
@@ -267,21 +241,21 @@ type PayloadValue struct {
 
 // formResultSecret creates the result secret using the result
 func (driver *KubeDriver) formResultSecret(r *base.ExperimentResult) (*corev1.Secret, error) {
-	job, err := driver.getExperimentJob()
+	spec, err := driver.getExperimentSpecSecret()
 	if err != nil {
 		return nil, err
 	}
-	// got job ...
+	// got spec secret ...
 
 	byteArray, _ := yaml.Marshal(r)
 	sec := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: driver.getResultSecretName(),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: job.APIVersion,
-				Kind:       job.Kind,
-				Name:       job.Name,
-				UID:        job.UID,
+				APIVersion: spec.APIVersion,
+				Kind:       spec.Kind,
+				Name:       spec.Name,
+				UID:        spec.UID,
 			}},
 		},
 		StringData: map[string]string{"result.yaml": string(byteArray)},

--- a/testdata/assertinputs/result.yaml
+++ b/testdata/assertinputs/result.yaml
@@ -125,6 +125,6 @@ insights:
     http/request-count:
     - 16
   numVersions: 1
-iter8Version: v0.9
+iter8Version: v0.10
 numCompletedTasks: 4
 startTime: "2022-03-16T10:22:58.540897-04:00"

--- a/testdata/assertinputsfail/result.yaml
+++ b/testdata/assertinputsfail/result.yaml
@@ -131,6 +131,6 @@ insights:
     http/request-count:
     - 16
   numVersions: 1
-iter8Version: v0.9
+iter8Version: v0.10
 numCompletedTasks: 4
 startTime: "2022-03-16T10:22:37.110424-04:00"

--- a/testdata/drivertests/experiment.yaml
+++ b/testdata/drivertests/experiment.yaml
@@ -13,8 +13,7 @@
     - 97.5
     - 99
     - 99.9
-    versionInfo:
-    - url: https://httpbin.org/get
+    url: https://httpbin.org/get
 # task 2: validate service level objectives for app using
 # the metrics collected in the above task
 - task: assess-app-versions

--- a/testdata/experiment.yaml
+++ b/testdata/experiment.yaml
@@ -13,8 +13,7 @@
     - 97.5
     - 99
     - 99.9
-    versionInfo:
-    - url: https://httpbin.org/get
+    url: https://httpbin.org/get
 # task 2: validate service level objectives for app using
 # the metrics collected in the above task
 - task: assess-app-versions


### PR DESCRIPTION
While attempting to run Kubernetes, I ran into a bunch of problems. This PR fixes some of them, and includes tests for them.

- [x] Created a post-release test for Kubernetes experimentation. This is post-release since we want to test with the Docker image created by the release process.
- [x] [A previous PR](#1206) removed payload / other URLs from HTTP and gRPC tasks in favor of local files. This PR enables them through charts (and curl commands). So payload URLs can be specified, without the need to worry about certificates etc. during load tests.
- [x] I had to remove the Docker build and push from Makefile. `ITER8_IMG ?= iter8/iter8:edge` is an invalid setting in makefile due to the presence of the colon. Additionally, using a colon in variable/filename is complicated as documented [here](https://stackoverflow.com/questions/2052406/escaping-colons-in-filenames-in-a-makefile). In particular, `make clean install` fails if I include that Docker build/push conf, and passes otherwise. Given that `docker build` and `push` can be accomplished through one-liners outside of the makefile, and given that we don't have a real need to build Docker images through CLIs, and given that it is starting to interfere with other commands in the makefile that are actually being used both during dev, and as part of CI, I think it makes sense to remove Docker build/push from makefile. Of course, if this is really required, we can enable it again in the future.
- [x] HTTP task now supports only a single version. This simplification makes every part of the code (iter8 CLI + charts) simpler. We can consider re-enabling multiple versions in the task if it ever becomes required during load tests in the future.
- [x] Removed appVersions which partly addresses #1212
- [x] Minor changes (like replacing the word subcommand with command in some places)
- [x] Previously, the owner of a result secret was the job that created it. Now it is the spec secret associated with it. They both have similar effect upon upgrades/deletions of experiments, however the code becomes simpler now.

***
**What remains to be done**

- [ ] Set `values.yaml` appropriately and also create proper documentation with `values.yaml`. TBD after the merge, since we will use the task  links within values.yaml docs to describe parameters. 

