### PR TITLE
Fix Kubernetes experimentation

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -106,7 +106,7 @@ jobs:
       run: |
         kubectl create deployment httpbin --image=kennethreitz/httpbin
         kubectl expose deployment httpbin --type=ClusterIP --port=80
-        kubectl wait --for=condition=Available --timeout=300s deployment/httpbin
+        kubectl wait --for=condition=available --timeout=300s deploy/httpbin
     - name: iter8 k launch
       run: |
         iter8 k launch -c load-test-http \
@@ -137,7 +137,7 @@ jobs:
       run: |
         kubectl create deploy hello --image=docker.io/grpc/java-example-hostname:latest --port=50051
         kubectl expose deploy hello --port=50051
-        kubectl wait --for=condition=Available --timeout=300s deployment/hello
+        kubectl wait --for=condition=available --timeout=300s deploy/hello
     - name: iter8 k launch
       run: |
         iter8 k launch -c load-test-grpc \

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -100,6 +100,8 @@ jobs:
     steps:
     - uses: iter8-tools/iter8@v0.10
     - uses: engineerd/setup-kind@v0.5.0
+      with:
+        version: "v0.12.0"    
     - name: create app
       run: |
         kubectl create deployment httpbin --image=kennethreitz/httpbin
@@ -129,6 +131,8 @@ jobs:
         tar -xvf iter8-linux-amd64.tar.gz
         mv linux-amd64/iter8 /usr/local/bin
     - uses: engineerd/setup-kind@v0.5.0
+      with:
+        version: "v0.12.0"    
     - name: create app
       run: |
         kubectl create deploy hello --image=docker.io/grpc/java-example-hostname:latest --port=50051

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -104,7 +104,7 @@ jobs:
       run: |
         kubectl create deployment httpbin --image=kennethreitz/httpbin
         kubectl expose deployment httpbin --type=ClusterIP --port=80
-        kubectl wait --for=condition=available --timeout=300s deployment/httpbin
+        kubectl wait --for=condition=Available --timeout=300s deployment/httpbin
     - name: iter8 k launch
       run: |
         iter8 k launch -c load-test-http \
@@ -133,7 +133,7 @@ jobs:
       run: |
         kubectl create deploy hello --image=docker.io/grpc/java-example-hostname:latest --port=50051
         kubectl expose deploy hello --port=50051
-        kubectl wait --for=condition=available --timeout=300s deployment/hello
+        kubectl wait --for=condition=Available --timeout=300s deployment/hello
     - name: iter8 k launch
       run: |
         iter8 k launch -c load-test-grpc \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -172,7 +172,7 @@ jobs:
         iter8 k launch -c load-test-http --noDownload \
         --set url="https://httpbin.org/post" \
         --set payloadURL="https://httpbin.org/stream/1" \
-        --set disable.job=true
+        --set iter8lib.disable.job=true
     - name: k run
       run: |
         iter8 k run --namespace default --group default

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -165,6 +165,8 @@ jobs:
     - name: Build and install Iter8
       run: make install
     - uses: engineerd/setup-kind@v0.5.0
+      with:
+        version: "v0.12.0"    
     - name: create app
       run: |
         kubectl create deployment httpbin --image=kennethreitz/httpbin

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -152,40 +152,35 @@ jobs:
       run: |
         iter8 assert -c completed -c nofailure
 
-  # kubernetes-http-experiment:
-  #   name: http load test inside Kubernetes
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Install Go
-  #     uses: actions/setup-go@v2
-  #     with:
-  #       go-version: 1.17
-  #   - name: Check out code into the Go module directory
-  #     uses: actions/checkout@v2
-  #   - name: Build and install Iter8
-  #     run: make install
-  #   - uses: engineerd/setup-kind@v0.5.0
-  #     with:
-  #       version: "v0.12.0"    
-  #   - name: create app
-  #     run: |
-  #       kubectl create deployment httpbin --image=kennethreitz/httpbin
-  #       kubectl expose deployment httpbin --type=ClusterIP --port=80
-  #       kubectl wait --for=condition=available --timeout=60s deploy/httpbin
-  #   - name: k launch load-test-http
-  #     run: |
-  #       iter8 k launch -c load-test-http --noDownload \
-  #       --set url="http://httpbin.default/post" \
-  #       --set payloadURL="https://httpbin.org/stream/1" \
-  #       --set disable.job=true
-  #   - name: k run
-  #     run: |
-  #       iter8 k run --namespace default --group default
-  #   - name: assert experiment completed without failures
-  #     run: |
-  #       iter8 assert -c completed -c nofailure --timeout 300s
-  #       iter8 k report
-  #       iter8 k delete
+  kubernetes-http-experiment:
+    name: http load test inside Kubernetes
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Build and install Iter8
+      run: make install
+    - uses: engineerd/setup-kind@v0.5.0
+      with:
+        version: "v0.12.0"    
+    - name: k launch load-test-http
+      run: |
+        iter8 k launch -c load-test-http --noDownload \
+        --set url="https://httpbin.org/post" \
+        --set payloadURL="https://httpbin.org/stream/1" \
+        --set disable.job=true
+    - name: k run
+      run: |
+        iter8 k run --namespace default --group default
+    - name: assert experiment completed without failures
+      run: |
+        iter8 assert -c completed -c nofailure --timeout 300s
+        iter8 k report
+        iter8 k delete
 
   static-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -171,7 +171,7 @@ jobs:
       run: |
         kubectl create deployment httpbin --image=kennethreitz/httpbin
         kubectl expose deployment httpbin --type=ClusterIP --port=80
-        kubectl wait --for=condition=Available --timeout=60s deployment/httpbin
+        kubectl wait --for=condition=available --timeout=60s deploy/httpbin
     - name: k launch load-test-http
       run: |
         iter8 k launch -c load-test-http --noDownload \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -152,6 +152,39 @@ jobs:
       run: |
         iter8 assert -c completed -c nofailure
 
+  kubernetes-http-experiment:
+    name: http load test inside Kubernetes
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Build and install Iter8
+      run: make install
+    - uses: engineerd/setup-kind@v0.5.0
+    - name: create app
+      run: |
+        kubectl create deployment httpbin --image=kennethreitz/httpbin
+        kubectl expose deployment httpbin --type=ClusterIP --port=80
+        kubectl wait --for=condition=Available --timeout=60s deployment/httpbin
+    - name: k launch load-test-http
+      run: |
+        iter8 k launch -c load-test-http --noDownload \
+        --set url="http://$HOST_IP/post" \
+        --set payloadURL="https://httpbin.org/stream/1" \
+        --set disable.job=true
+    - name: k run
+      run: |
+        iter8 k run --namespace default --group default
+    - name: assert experiment completed without failures
+      run: |
+        iter8 assert -c completed -c nofailure --timeout 300s
+        iter8 k report
+        iter8 k delete
+
   static-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -175,7 +175,7 @@ jobs:
     - name: k launch load-test-http
       run: |
         iter8 k launch -c load-test-http --noDownload \
-        --set url="http://$HOST_IP/post" \
+        --set url="http://httpbin.default/post" \
         --set payloadURL="https://httpbin.org/stream/1" \
         --set disable.job=true
     - name: k run

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -152,40 +152,40 @@ jobs:
       run: |
         iter8 assert -c completed -c nofailure
 
-  kubernetes-http-experiment:
-    name: http load test inside Kubernetes
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    - name: Build and install Iter8
-      run: make install
-    - uses: engineerd/setup-kind@v0.5.0
-      with:
-        version: "v0.12.0"    
-    - name: create app
-      run: |
-        kubectl create deployment httpbin --image=kennethreitz/httpbin
-        kubectl expose deployment httpbin --type=ClusterIP --port=80
-        kubectl wait --for=condition=available --timeout=60s deploy/httpbin
-    - name: k launch load-test-http
-      run: |
-        iter8 k launch -c load-test-http --noDownload \
-        --set url="http://httpbin.default/post" \
-        --set payloadURL="https://httpbin.org/stream/1" \
-        --set disable.job=true
-    - name: k run
-      run: |
-        iter8 k run --namespace default --group default
-    - name: assert experiment completed without failures
-      run: |
-        iter8 assert -c completed -c nofailure --timeout 300s
-        iter8 k report
-        iter8 k delete
+  # kubernetes-http-experiment:
+  #   name: http load test inside Kubernetes
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Install Go
+  #     uses: actions/setup-go@v2
+  #     with:
+  #       go-version: 1.17
+  #   - name: Check out code into the Go module directory
+  #     uses: actions/checkout@v2
+  #   - name: Build and install Iter8
+  #     run: make install
+  #   - uses: engineerd/setup-kind@v0.5.0
+  #     with:
+  #       version: "v0.12.0"    
+  #   - name: create app
+  #     run: |
+  #       kubectl create deployment httpbin --image=kennethreitz/httpbin
+  #       kubectl expose deployment httpbin --type=ClusterIP --port=80
+  #       kubectl wait --for=condition=available --timeout=60s deploy/httpbin
+  #   - name: k launch load-test-http
+  #     run: |
+  #       iter8 k launch -c load-test-http --noDownload \
+  #       --set url="http://httpbin.default/post" \
+  #       --set payloadURL="https://httpbin.org/stream/1" \
+  #       --set disable.job=true
+  #   - name: k run
+  #     run: |
+  #       iter8 k run --namespace default --group default
+  #   - name: assert experiment completed without failures
+  #     run: |
+  #       iter8 assert -c completed -c nofailure --timeout 300s
+  #       iter8 k report
+  #       iter8 k delete
 
   static-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -178,7 +178,7 @@ jobs:
         iter8 k run --namespace default --group default
     - name: assert experiment completed without failures
       run: |
-        iter8 assert -c completed -c nofailure --timeout 300s
+        iter8 k assert -c completed -c nofailure --timeout 300s
         iter8 k report
         iter8 k delete
 

--- a/charts/iter8lib/templates/_k-job.tpl
+++ b/charts/iter8lib/templates/_k-job.tpl
@@ -2,9 +2,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-{{ .Release.Revision }}-job
+  name: {{ .Release.Name }}-{{ .Release.Revision | toString }}-job
   annotations:
-    iter8.tools/revision: {{ .Release.Revision }}
+    iter8.tools/revision: {{ .Release.Revision | toString }}
 spec:
   template:
     spec:

--- a/charts/iter8lib/templates/_k-job.tpl
+++ b/charts/iter8lib/templates/_k-job.tpl
@@ -2,9 +2,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-{{ .Release.Revision | toString }}-job
+  name: {{ .Release.Name }}-{{ .Release.Revision }}-job
   annotations:
-    iter8.tools/revision: {{ .Release.Revision | toString }}
+    iter8.tools/revision: {{ .Release.Revision | quote }}
 spec:
   template:
     spec:

--- a/charts/iter8lib/templates/_k-manifest.tpl
+++ b/charts/iter8lib/templates/_k-manifest.tpl
@@ -10,7 +10,7 @@
 {{ include "k.result.role" . }}
 ---
 {{ include "k.result.rolebinding" . }}
-{{- if not .Values.disable.job }}
+{{- if not .Values.iter8lib.disable.job }}
 ---
 {{ include "k.job" . }}
 {{- end }}

--- a/charts/iter8lib/templates/_k-manifest.tpl
+++ b/charts/iter8lib/templates/_k-manifest.tpl
@@ -1,6 +1,4 @@
 {{- define "k.manifest" -}}
-{{ include "k.job" . }}
----
 {{ include "k.spec.secret" . }}
 ---
 {{ include "k.spec.role" . }}
@@ -12,4 +10,8 @@
 {{ include "k.result.role" . }}
 ---
 {{ include "k.result.rolebinding" . }}
+{{- if not .Values.disable.job }}
+---
+{{ include "k.job" . }}
+{{- end }}
 {{- end }}

--- a/charts/iter8lib/templates/_k-result-role.tpl
+++ b/charts/iter8lib/templates/_k-result-role.tpl
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: {{ .Release.Name }}-result-role
   annotations:
-    iter8.tools/revision: {{ .Release.Revision | toString }}
+    iter8.tools/revision: {{ .Release.Revision | quote }}
 rules:
 - apiGroups: [""]
   resourceNames: ["{{ .Release.Name }}-result"]

--- a/charts/iter8lib/templates/_k-result-role.tpl
+++ b/charts/iter8lib/templates/_k-result-role.tpl
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: {{ .Release.Name }}-result-role
   annotations:
-    iter8.tools/revision: {{ .Release.Revision }}
+    iter8.tools/revision: {{ .Release.Revision | toString }}
 rules:
 - apiGroups: [""]
   resourceNames: ["{{ .Release.Name }}-result"]

--- a/charts/iter8lib/templates/_k-result-rolebinding.tpl
+++ b/charts/iter8lib/templates/_k-result-rolebinding.tpl
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-result-rolebinding
   annotations:
-    iter8.tools/revision: {{ .Release.Revision }}
+    iter8.tools/revision: {{ .Release.Revision | toString }}
 subjects:
 - kind: ServiceAccount
   name: default

--- a/charts/iter8lib/templates/_k-result-rolebinding.tpl
+++ b/charts/iter8lib/templates/_k-result-rolebinding.tpl
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-result-rolebinding
   annotations:
-    iter8.tools/revision: {{ .Release.Revision | toString }}
+    iter8.tools/revision: {{ .Release.Revision | quote }}
 subjects:
 - kind: ServiceAccount
   name: default

--- a/charts/iter8lib/templates/_k-result-secret.tpl
+++ b/charts/iter8lib/templates/_k-result-secret.tpl
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-result
   annotations:
-    iter8.tools/revision: {{ .Release.Revision | toString }}
+    iter8.tools/revision: {{ .Release.Revision | quote }}
 stringData:
   experiment.yaml: |
     startTime:         {{ now | toString }}

--- a/charts/iter8lib/templates/_k-result-secret.tpl
+++ b/charts/iter8lib/templates/_k-result-secret.tpl
@@ -4,11 +4,11 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-result
   annotations:
-    iter8.tools/revision: {{ .Release.Revision }}
+    iter8.tools/revision: {{ .Release.Revision | toString }}
 stringData:
   experiment.yaml: |
-    startTime:         {{ now }},
-    numCompletedTasks: 0,
-    failure:           false,
-    iter8Version:      {{ .Values.iter8lib.majorMinor }},
+    startTime:         {{ now | toString }}
+    numCompletedTasks: 0
+    failure:           false
+    iter8Version:      {{ .Values.iter8lib.majorMinor }}
 {{- end }}

--- a/charts/iter8lib/templates/_k-spec-role.tpl
+++ b/charts/iter8lib/templates/_k-spec-role.tpl
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: {{ .Release.Name }}-spec-role
   annotations:
-    iter8.tools/revision: {{ .Release.Revision | toString }}
+    iter8.tools/revision: {{ .Release.Revision | quote }}
 rules:
 - apiGroups: [""]
   resourceNames: ["{{ .Release.Name }}-spec"]

--- a/charts/iter8lib/templates/_k-spec-role.tpl
+++ b/charts/iter8lib/templates/_k-spec-role.tpl
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: {{ .Release.Name }}-spec-role
   annotations:
-    iter8.tools/revision: {{ .Release.Revision }}
+    iter8.tools/revision: {{ .Release.Revision | toString }}
 rules:
 - apiGroups: [""]
   resourceNames: ["{{ .Release.Name }}-spec"]

--- a/charts/iter8lib/templates/_k-spec-rolebinding.tpl
+++ b/charts/iter8lib/templates/_k-spec-rolebinding.tpl
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-spec-rolebinding
   annotations:
-    iter8.tools/revision: {{ .Release.Revision | toString }}
+    iter8.tools/revision: {{ .Release.Revision | quote }}
 subjects:
 - kind: ServiceAccount
   name: default

--- a/charts/iter8lib/templates/_k-spec-rolebinding.tpl
+++ b/charts/iter8lib/templates/_k-spec-rolebinding.tpl
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-spec-rolebinding
   annotations:
-    iter8.tools/revision: {{ .Release.Revision }}
+    iter8.tools/revision: {{ .Release.Revision | toString }}
 subjects:
 - kind: ServiceAccount
   name: default

--- a/charts/iter8lib/templates/_k-spec-secret.tpl
+++ b/charts/iter8lib/templates/_k-spec-secret.tpl
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-spec
   annotations:
-    iter8.tools/revision: {{ .Release.Revision | toString }}
+    iter8.tools/revision: {{ .Release.Revision | quote }}
 stringData:
   experiment.yaml: |
 {{- include "experiment" . | indent 4 }}

--- a/charts/iter8lib/templates/_k-spec-secret.tpl
+++ b/charts/iter8lib/templates/_k-spec-secret.tpl
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-spec
   annotations:
-    iter8.tools/revision: {{ .Release.Revision }}
+    iter8.tools/revision: {{ .Release.Revision | toString }}
 stringData:
   experiment.yaml: |
 {{- include "experiment" . | indent 4 }}

--- a/charts/iter8lib/values.yaml
+++ b/charts/iter8lib/values.yaml
@@ -3,3 +3,10 @@ iter8Image: iter8/iter8:0.10
 
 ### majorMinor is the minor version of Iter8
 majorMinor: v0.10
+
+### disable Manifests that should be disabled. This is useful for testing purposes.
+### By default, no manifest is disabled.
+### To disable the job manifest, uncomment the next two lines and delete the line after that.
+### disable
+###   job: true
+disable: {}


### PR DESCRIPTION
Fix more issues in Kubernetes experimentation
1. Revisions in annotations are now strings
2. Newer version of kind is required for `kubectl wait` to work
3. Format of experiment.yaml in secret is fixed
4. Job manifest can be selectively disabled (useful for testing purposes)