### PR TITLE
Db task with providers

### DIFF
--- a/base/collect_database.go
+++ b/base/collect_database.go
@@ -46,9 +46,9 @@ type Params struct {
 }
 
 const (
-	StartingTime = "StartingTime"
-	ElapsedTime  = "ElapsedTime"
-	TimeLayout   = "Jan 2, 2006 at 3:04pm (MST)"
+	startingTimeStr = "StartingTime"
+	elapsedTimeStr  = "ElapsedTime"
+	timeLayout      = "Jan 2, 2006 at 3:04pm (MST)"
 )
 
 type collectDatabaseInputs struct {
@@ -83,17 +83,17 @@ func (t *collectDatabaseTask) validateInputs() error {
 // starting time in the Experiment
 func getElapsedTime(versionInfo map[string]interface{}, exp *Experiment) (int64, error) {
 	// ElapsedTime should not be provided by the user
-	if versionInfo[ElapsedTime] != nil {
+	if versionInfo[elapsedTimeStr] != nil {
 		return 0, errors.New("ElapsedTime should not be provided by the user in VersionInfo: " + fmt.Sprintf("%v", versionInfo))
 	}
 
 	startingTime := exp.Result.StartTime.Unix()
-	if versionInfo[StartingTime] != nil {
+	if versionInfo[startingTimeStr] != nil {
 		// Calling Parse() method with its parameters
-		temp, err := time.Parse(TimeLayout, fmt.Sprintf("%v", versionInfo[StartingTime]))
+		temp, err := time.Parse(timeLayout, fmt.Sprintf("%v", versionInfo[startingTimeStr]))
 
 		if err != nil {
-			return 0, errors.New("Cannot parse startingTime")
+			return 0, errors.New("cannot parse startingTime")
 		} else {
 			startingTime = temp.Unix()
 		}
@@ -210,7 +210,7 @@ func (t *collectDatabaseTask) run(exp *Experiment) error {
 			if err != nil {
 				return err
 			}
-			versionInfo[ElapsedTime] = elapsedTime
+			versionInfo[elapsedTimeStr] = elapsedTime
 
 			// finalize metrics template
 			template, err := template.ParseFiles(provider + ".metrics.yaml")

--- a/base/collect_database_test.go
+++ b/base/collect_database_test.go
@@ -14,7 +14,7 @@ import (
 const (
 	templatePath      = "../testdata/templates/ce.metrics.tpl"
 	tempMetricsPath   = "test-ce.metrics.yaml"
-	TestCe            = "test-ce"
+	testCe            = "test-ce"
 	testPromURL       = `test-database.com/prometheus/api/v1/query?query=`
 	requestCountQuery = "sum(last_over_time(ibm_codeengine_application_requests_total{\n" +
 		"}[0s])) or on() vector(0)\n"
@@ -111,7 +111,7 @@ func TestCEOneVersion(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{TestCe},
+			Providers: []string{testCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}},
@@ -222,7 +222,7 @@ func TestCEUnauthorized(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{TestCe},
+			Providers: []string{testCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}},
@@ -289,7 +289,7 @@ func TestCESomeValues(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{TestCe},
+			Providers: []string{testCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}},
@@ -394,7 +394,7 @@ func TestCEMultipleVersions(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{TestCe},
+			Providers: []string{testCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}, {
@@ -503,7 +503,7 @@ func TestCEMultipleVersionsAndMetrics(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{TestCe},
+			Providers: []string{testCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}, {

--- a/base/collect_database_test.go
+++ b/base/collect_database_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	templatePath      string = "../testdata/templates/ce.metrics.tpl"
-	tempMetricsPath   string = "test-ce.metrics.yaml"
-	testPromURL              = `test-database.com/prometheus/api/v1/query?query=`
-	requestCountQuery        = "sum(last_over_time(ibm_codeengine_application_requests_total{\n" +
+	templatePath      = "../testdata/templates/ce.metrics.tpl"
+	tempMetricsPath   = "test-ce.metrics.yaml"
+	TestCe            = "test-ce"
+	testPromURL       = `test-database.com/prometheus/api/v1/query?query=`
+	requestCountQuery = "sum(last_over_time(ibm_codeengine_application_requests_total{\n" +
 		"}[0s])) or on() vector(0)\n"
 	errorCountQuery = "sum(last_over_time(ibm_codeengine_application_requests_total{\n" +
 		"  ibm_codeengine_status!=\"200\",\n" +
@@ -110,7 +111,7 @@ func TestCEOneVersion(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{"test-ce"},
+			Providers: []string{TestCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}},
@@ -221,7 +222,7 @@ func TestCEUnauthorized(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{"test-ce"},
+			Providers: []string{TestCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}},
@@ -288,7 +289,7 @@ func TestCESomeValues(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{"test-ce"},
+			Providers: []string{TestCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}},
@@ -393,7 +394,7 @@ func TestCEMultipleVersions(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{"test-ce"},
+			Providers: []string{TestCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}, {
@@ -502,7 +503,7 @@ func TestCEMultipleVersionsAndMetrics(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
-			Providers: []string{"test-ce"},
+			Providers: []string{TestCe},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}, {

--- a/base/collect_database_test.go
+++ b/base/collect_database_test.go
@@ -63,7 +63,7 @@ func executeTemplate(inputs map[string]interface{}, templatePath string, writePa
 func TestGetElapsedTime(t *testing.T) {
 	versionInfo := map[string]interface{}{
 		"ibm_service_instance": "version1",
-		"StartingTime":         1000,
+		"StartingTime":         "Feb 4, 2014 at 6:05pm (PST)",
 	}
 
 	exp := &Experiment{

--- a/base/collect_database_test.go
+++ b/base/collect_database_test.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"encoding/json"
+	"net/url"
 	"os"
 	"testing"
 	"text/template"
@@ -10,13 +11,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var templatePath string = "../testdata/templates/ce.metrics.tpl"
-var tempMetricsPath string = "test-ce.metrics.yaml"
+const (
+	templatePath      string = "../testdata/templates/ce.metrics.tpl"
+	tempMetricsPath   string = "test-ce.metrics.yaml"
+	testPromURL              = `test-database.com/prometheus/api/v1/query?query=`
+	requestCountQuery        = "sum(last_over_time(ibm_codeengine_application_requests_total{\n" +
+		"}[0s])) or on() vector(0)\n"
+	errorCountQuery = "sum(last_over_time(ibm_codeengine_application_requests_total{\n" +
+		"  ibm_codeengine_status!=\"200\",\n" +
+		"}[0s])) or on() vector(0)\n"
+	errorRateQuery = "sum(last_over_time(ibm_codeengine_application_requests_total{\n" +
+		"  ibm_codeengine_status!=\"200\",\n" +
+		"}[0s])) or on() vector(0)/sum(last_over_time(ibm_codeengine_application_requests_total{\n" +
+		"}[0s])) or on() vector(0)\n"
+)
 
 type collectDatabaseTemplateInput struct {
-	MonitoringEndpoint string `json:"MonitoringEndpoint" yaml:"MonitoringEndpoint"`
-	IAMToken           string `json:"IAMToken" yaml:"IAMToken"`
-	GUID               string `json:"GUID" yaml:"GUID"`
+	Endpoint string `json:"endpoint" yaml:"endpoint"`
+	IAMToken string `json:"IAMToken" yaml:"IAMToken"`
+	GUID     string `json:"GUID" yaml:"GUID"`
 }
 
 // has to be a map[string]string in order to do input checks in template
@@ -75,9 +88,9 @@ func TestGetElapsedTime(t *testing.T) {
 func TestCEOneVersion(t *testing.T) {
 	// create metrics file from template
 	input := &collectDatabaseTemplateInput{
-		MonitoringEndpoint: "test-database.com",
-		IAMToken:           "test-token",
-		GUID:               "test-guid",
+		Endpoint: "test-database.com",
+		IAMToken: "test-token",
+		GUID:     "test-guid",
 	}
 
 	// convert input to map[string]interface{}
@@ -97,6 +110,7 @@ func TestCEOneVersion(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
+			Providers: []string{"test-ce"},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}},
@@ -106,7 +120,7 @@ func TestCEOneVersion(t *testing.T) {
 	httpmock.Activate()
 
 	// request-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(requestCountQuery),
 		httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
@@ -124,7 +138,7 @@ func TestCEOneVersion(t *testing.T) {
 		}`))
 
 	// error-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29++%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorCountQuery),
 		httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
@@ -142,7 +156,7 @@ func TestCEOneVersion(t *testing.T) {
 		}`))
 
 	// error-rate
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29%2Fsum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorRateQuery),
 		httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
@@ -186,9 +200,9 @@ func TestCEOneVersion(t *testing.T) {
 func TestCEUnauthorized(t *testing.T) {
 	// create metrics file from template
 	input := &collectDatabaseTemplateInput{
-		MonitoringEndpoint: "test-database.com",
-		IAMToken:           "test-token",
-		GUID:               "test-guid",
+		Endpoint: "test-database.com",
+		IAMToken: "test-token",
+		GUID:     "test-guid",
 	}
 
 	// convert input to map[string]interface{}
@@ -207,6 +221,7 @@ func TestCEUnauthorized(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
+			Providers: []string{"test-ce"},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}},
@@ -216,15 +231,15 @@ func TestCEUnauthorized(t *testing.T) {
 	httpmock.Activate()
 
 	// request-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(requestCountQuery),
 		httpmock.NewStringResponder(401, `Unauthorized`))
 
 	// error-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29++%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorCountQuery),
 		httpmock.NewStringResponder(401, `Unauthorized`))
 
 	// error-rate
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29%2Fsum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorRateQuery),
 		httpmock.NewStringResponder(401, `Unauthorized`))
 
 	exp := &Experiment{
@@ -252,9 +267,9 @@ func TestCEUnauthorized(t *testing.T) {
 func TestCESomeValues(t *testing.T) {
 	// create metrics file from template
 	input := &collectDatabaseTemplateInput{
-		MonitoringEndpoint: "test-database.com",
-		IAMToken:           "test-token",
-		GUID:               "test-guid",
+		Endpoint: "test-database.com",
+		IAMToken: "test-token",
+		GUID:     "test-guid",
 	}
 
 	// convert input to map[string]interface{}
@@ -273,6 +288,7 @@ func TestCESomeValues(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
+			Providers: []string{"test-ce"},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}},
@@ -282,8 +298,7 @@ func TestCESomeValues(t *testing.T) {
 	httpmock.Activate()
 
 	// request-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
-		httpmock.NewStringResponder(200, `{
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(requestCountQuery), httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
 				"resultType": "vector",
@@ -292,7 +307,7 @@ func TestCESomeValues(t *testing.T) {
 		}`))
 
 	// error-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29++%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorCountQuery),
 		httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
@@ -310,7 +325,7 @@ func TestCESomeValues(t *testing.T) {
 		}`))
 
 	// error-rate
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29%2Fsum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorRateQuery),
 		httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
@@ -357,9 +372,9 @@ func TestCESomeValues(t *testing.T) {
 func TestCEMultipleVersions(t *testing.T) {
 	// create metrics file from template
 	input := &collectDatabaseTemplateInput{
-		MonitoringEndpoint: "test-database.com",
-		IAMToken:           "test-token",
-		GUID:               "test-guid",
+		Endpoint: "test-database.com",
+		IAMToken: "test-token",
+		GUID:     "test-guid",
 	}
 
 	// convert input to map[string]interface{}
@@ -378,6 +393,7 @@ func TestCEMultipleVersions(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
+			Providers: []string{"test-ce"},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}, {
@@ -389,8 +405,7 @@ func TestCEMultipleVersions(t *testing.T) {
 	httpmock.Activate()
 
 	// request-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
-		httpmock.NewStringResponder(200, `{
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(requestCountQuery), httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
 				"resultType": "vector",
@@ -399,7 +414,7 @@ func TestCEMultipleVersions(t *testing.T) {
 		}`))
 
 	// error-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29++%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorCountQuery),
 		httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
@@ -417,7 +432,7 @@ func TestCEMultipleVersions(t *testing.T) {
 		}`))
 
 	// error-rate
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29%2Fsum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorRateQuery),
 		httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
@@ -466,9 +481,9 @@ func TestCEMultipleVersions(t *testing.T) {
 func TestCEMultipleVersionsAndMetrics(t *testing.T) {
 	// create metrics file from template
 	input := &collectDatabaseTemplateInput{
-		MonitoringEndpoint: "test-database.com",
-		IAMToken:           "test-token",
-		GUID:               "test-guid",
+		Endpoint: "test-database.com",
+		IAMToken: "test-token",
+		GUID:     "test-guid",
 	}
 
 	// convert input to map[string]interface{}
@@ -487,6 +502,7 @@ func TestCEMultipleVersionsAndMetrics(t *testing.T) {
 			Task: StringPointer(CollectDatabaseTaskName),
 		},
 		With: collectDatabaseInputs{
+			Providers: []string{"test-ce"},
 			VersionInfo: []map[string]interface{}{{
 				"ibm_service_instance": "version1",
 			}, {
@@ -498,8 +514,7 @@ func TestCEMultipleVersionsAndMetrics(t *testing.T) {
 	httpmock.Activate()
 
 	// request-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
-		httpmock.NewStringResponder(200, `{
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(requestCountQuery), httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
 				"resultType": "vector",
@@ -508,7 +523,7 @@ func TestCEMultipleVersionsAndMetrics(t *testing.T) {
 		}`))
 
 	// error-count
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29++%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorCountQuery),
 		httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {
@@ -526,7 +541,7 @@ func TestCEMultipleVersionsAndMetrics(t *testing.T) {
 		}`))
 
 	// error-rate
-	httpmock.RegisterResponder("GET", `test-database.com/prometheus/api/v1/query?query=sum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A++ibm_codeengine_status%21%3D%22200%22%2C%0A%7D%5B0s%5D%29%29%2Fsum%28last_over_time%28ibm_codeengine_application_requests_total%7B%0A%7D%5B0s%5D%29%29+%0A`,
+	httpmock.RegisterResponder("GET", testPromURL+url.QueryEscape(errorRateQuery),
 		httpmock.NewStringResponder(200, `{
 			"status": "success",
 			"data": {

--- a/charts/load-test-http/values.yaml
+++ b/charts/load-test-http/values.yaml
@@ -10,7 +10,7 @@
 
 ### In addition, this chart supports the following parameters.
 
-### payloadUrl    URL of payload. If this field is specified, 
+### payloadURL    URL of payload. If this field is specified, 
 ### Iter8 will send HTTP POST requests to versions with 
 ### data downloaded from this URL as the payload.
 # payloadURL: null

--- a/testdata/templates/ce.metrics.tpl
+++ b/testdata/templates/ce.metrics.tpl
@@ -26,7 +26,7 @@ method: GET
 #
 # Inputs for the metrics (output of template):
 #   ibm_codeengine_revision_name string
-#   StartingTime                 int64 (UNIX time stamp)
+#   StartingTime                 string
 #
 # Note: ElapsedTime is produced by Iter8
 metrics:

--- a/testdata/templates/ce.metrics.tpl
+++ b/testdata/templates/ce.metrics.tpl
@@ -1,6 +1,6 @@
 # endpoint where the monitoring instance is available
 # https://cloud.ibm.com/docs/monitoring?topic=monitoring-endpoints#endpoints_sysdig
-url: {{ .MonitoringEndpoint }}/prometheus/api/v1/query # e.g. https://ca-tor.monitoring.cloud.ibm.com/api/data
+url: {{ .endpoint }}/prometheus/api/v1/query # e.g. https://ca-tor.monitoring.cloud.ibm.com
 headers:
   # IAM token
   # to get the token, run: ibmcloud iam oauth-tokens | grep IAM | cut -d \: -f 2 | sed 's/^ *//'
@@ -9,7 +9,7 @@ headers:
   # to get the GUID, run: ibmcloud resource service-instance <NAME> --output json | jq -r '.[].guid'
   # https://cloud.ibm.com/docs/monitoring?topic=monitoring-mon-curl
   IBMInstanceID: {{ .GUID }}
-provider: IBM Cloud Code Engine Sysdig
+provider: ce
 method: GET
 # Inputs for the template:
 #   ibm_codeengine_application_name string
@@ -33,165 +33,165 @@ metrics:
 - name: request-count
   type: counter
   description: |
-    The number of requests sent to the Code Engine application.
+    Number of requests
   params:
   - name: query
     value: |
       sum(last_over_time(ibm_codeengine_application_requests_total{
         {{- if .ibm_codeengine_application_name }}
-          ibm_codeengine_application_name="{{ .ibm_codeengine_application_name}}",
+          ibm_codeengine_application_name="{{.ibm_codeengine_application_name}}",
         {{- end }}
         {{- if .ibm_codeengine_gateway_instance }}
-          ibm_codeengine_gateway_instance="{{ .ibm_codeengine_gateway_instance}}",
+          ibm_codeengine_gateway_instance="{{.ibm_codeengine_gateway_instance}}",
         {{- end }}
         {{- if .ibm_codeengine_namespace }}
-          ibm_codeengine_namespace="{{ .ibm_codeengine_namespace}}",
+          ibm_codeengine_namespace="{{.ibm_codeengine_namespace}}",
         {{- end }}
         {{- if .ibm_codeengine_project_name }}
-          ibm_codeengine_project_name="{{ .ibm_codeengine_project_name}}",
+          ibm_codeengine_project_name="{{.ibm_codeengine_project_name}}",
         {{- end }}
         {{- if .ibm_codeengine_status }}
-          ibm_codeengine_status="{{ .ibm_codeengine_status}}",
+          ibm_codeengine_status="{{.ibm_codeengine_status}}",
         {{- end }}
         {{- if .ibm_ctype }}
-          ibm_ctype="{{ .ibm_ctype}}",
+          ibm_ctype="{{.ibm_ctype}}",
         {{- end }}
         {{- if .ibm_location }}
-          ibm_location="{{ .ibm_location}}",
+          ibm_location="{{.ibm_location}}",
         {{- end }}
         {{- if .ibm_scope }}
-          ibm_scope="{{ .ibm_scope}}",
+          ibm_scope="{{.ibm_scope}}",
         {{- end }}
         {{- if .ibm_service_instance }}
-          ibm_service_instance="{{ .ibm_service_instance}}",
+          ibm_service_instance="{{.ibm_service_instance}}",
         {{- end }}
         {{- if .ibm_service_name }}
-          ibm_service_name="{{ .ibm_service_name}}",
+          ibm_service_name="{{.ibm_service_name}}",
         {{- end }}
         {{"{{"}}- if .ibm_codeengine_revision_name {{"}}"}}
           ibm_codeengine_revision_name="{{"{{"}}.ibm_codeengine_revision_name{{"}}"}}",
         {{"{{"}}- end {{"}}"}}
-      }[{{"{{"}}.ElapsedTime{{"}}"}}s])) 
+      }[{{"{{"}}.ElapsedTime{{"}}"}}s])) or on() vector(0)
   jqExpression: .data.result[0].value[1]
 - name: error-count
   type: counter
   description: |
-    The number of non-successful requests sent to the Code Engine application.
+    Number of non-successful requests
   params:
   - name: query
     value: |
       sum(last_over_time(ibm_codeengine_application_requests_total{
         ibm_codeengine_status!="200",
         {{- if .ibm_codeengine_application_name }}
-          ibm_codeengine_application_name="{{ .ibm_codeengine_application_name}}",
+          ibm_codeengine_application_name="{{.ibm_codeengine_application_name}}",
         {{- end }}
         {{- if .ibm_codeengine_gateway_instance }}
-          ibm_codeengine_gateway_instance="{{ .ibm_codeengine_gateway_instance}}",
+          ibm_codeengine_gateway_instance="{{.ibm_codeengine_gateway_instance}}",
         {{- end }}
         {{- if .ibm_codeengine_namespace }}
-          ibm_codeengine_namespace="{{ .ibm_codeengine_namespace}}",
+          ibm_codeengine_namespace="{{.ibm_codeengine_namespace}}",
         {{- end }}
         {{- if .ibm_codeengine_project_name }}
-          ibm_codeengine_project_name="{{ .ibm_codeengine_project_name}}",
+          ibm_codeengine_project_name="{{.ibm_codeengine_project_name}}",
         {{- end }}
         {{- if .ibm_codeengine_status }}
-          ibm_codeengine_status="{{ .ibm_codeengine_status}}",
+          ibm_codeengine_status="{{.ibm_codeengine_status}}",
         {{- end }}
         {{- if .ibm_ctype }}
-          ibm_ctype="{{ .ibm_ctype}}",
+          ibm_ctype="{{.ibm_ctype}}",
         {{- end }}
         {{- if .ibm_location }}
-          ibm_location="{{ .ibm_location}}",
+          ibm_location="{{.ibm_location}}",
         {{- end }}
         {{- if .ibm_scope }}
-          ibm_scope="{{ .ibm_scope}}",
+          ibm_scope="{{.ibm_scope}}",
         {{- end }}
         {{- if .ibm_service_instance }}
-          ibm_service_instance="{{ .ibm_service_instance}}",
+          ibm_service_instance="{{.ibm_service_instance}}",
         {{- end }}
         {{- if .ibm_service_name }}
-          ibm_service_name="{{ .ibm_service_name}}",
+          ibm_service_name="{{.ibm_service_name}}",
         {{- end }}
         {{"{{"}}- if .ibm_codeengine_revision_name {{"}}"}}
           ibm_codeengine_revision_name="{{"{{"}}.ibm_codeengine_revision_name{{"}}"}}",
         {{"{{"}}- end {{"}}"}}
-      }[{{"{{"}}.ElapsedTime{{"}}"}}s]))  
+      }[{{"{{"}}.ElapsedTime{{"}}"}}s])) or on() vector(0)
   jqExpression: .data.result[0].value[1]
 - name: error-rate
   type: gauge
   description: |
-    The number of non-successful requests sent to the Code Engine application.
+    Percentage of non-successful requests
   params:
   - name: query
     value: |
       sum(last_over_time(ibm_codeengine_application_requests_total{
         ibm_codeengine_status!="200",
         {{- if .ibm_codeengine_application_name }}
-          ibm_codeengine_application_name="{{ .ibm_codeengine_application_name}}",
+          ibm_codeengine_application_name="{{.ibm_codeengine_application_name}}",
         {{- end }}
         {{- if .ibm_codeengine_gateway_instance }}
-          ibm_codeengine_gateway_instance="{{ .ibm_codeengine_gateway_instance}}",
+          ibm_codeengine_gateway_instance="{{.ibm_codeengine_gateway_instance}}",
         {{- end }}
         {{- if .ibm_codeengine_namespace }}
-          ibm_codeengine_namespace="{{ .ibm_codeengine_namespace}}",
+          ibm_codeengine_namespace="{{.ibm_codeengine_namespace}}",
         {{- end }}
         {{- if .ibm_codeengine_project_name }}
-          ibm_codeengine_project_name="{{ .ibm_codeengine_project_name}}",
+          ibm_codeengine_project_name="{{.ibm_codeengine_project_name}}",
         {{- end }}
         {{- if .ibm_codeengine_status }}
-          ibm_codeengine_status="{{ .ibm_codeengine_status}}",
+          ibm_codeengine_status="{{.ibm_codeengine_status}}",
         {{- end }}
         {{- if .ibm_ctype }}
-          ibm_ctype="{{ .ibm_ctype}}",
+          ibm_ctype="{{.ibm_ctype}}",
         {{- end }}
         {{- if .ibm_location }}
-          ibm_location="{{ .ibm_location}}",
+          ibm_location="{{.ibm_location}}",
         {{- end }}
         {{- if .ibm_scope }}
-          ibm_scope="{{ .ibm_scope}}",
+          ibm_scope="{{.ibm_scope}}",
         {{- end }}
         {{- if .ibm_service_instance }}
-          ibm_service_instance="{{ .ibm_service_instance}}",
+          ibm_service_instance="{{.ibm_service_instance}}",
         {{- end }}
         {{- if .ibm_service_name }}
-          ibm_service_name="{{ .ibm_service_name}}",
+          ibm_service_name="{{.ibm_service_name}}",
         {{- end }}
         {{"{{"}}- if .ibm_codeengine_revision_name {{"}}"}}
           ibm_codeengine_revision_name="{{"{{"}}.ibm_codeengine_revision_name{{"}}"}}",
         {{"{{"}}- end {{"}}"}}
-      }[{{"{{"}}.ElapsedTime{{"}}"}}s]))/sum(last_over_time(ibm_codeengine_application_requests_total{
+      }[{{"{{"}}.ElapsedTime{{"}}"}}s])) or on() vector(0)/sum(last_over_time(ibm_codeengine_application_requests_total{
         {{- if .ibm_codeengine_application_name }}
-          ibm_codeengine_application_name="{{ .ibm_codeengine_application_name}}",
+          ibm_codeengine_application_name="{{.ibm_codeengine_application_name}}",
         {{- end }}
         {{- if .ibm_codeengine_gateway_instance }}
-          ibm_codeengine_gateway_instance="{{ .ibm_codeengine_gateway_instance}}",
+          ibm_codeengine_gateway_instance="{{.ibm_codeengine_gateway_instance}}",
         {{- end }}
         {{- if .ibm_codeengine_namespace }}
-          ibm_codeengine_namespace="{{ .ibm_codeengine_namespace}}",
+          ibm_codeengine_namespace="{{.ibm_codeengine_namespace}}",
         {{- end }}
         {{- if .ibm_codeengine_project_name }}
-          ibm_codeengine_project_name="{{ .ibm_codeengine_project_name}}",
+          ibm_codeengine_project_name="{{.ibm_codeengine_project_name}}",
         {{- end }}
         {{- if .ibm_codeengine_status }}
-          ibm_codeengine_status="{{ .ibm_codeengine_status}}",
+          ibm_codeengine_status="{{.ibm_codeengine_status}}",
         {{- end }}
         {{- if .ibm_ctype }}
-          ibm_ctype="{{ .ibm_ctype}}",
+          ibm_ctype="{{.ibm_ctype}}",
         {{- end }}
         {{- if .ibm_location }}
-          ibm_location="{{ .ibm_location}}",
+          ibm_location="{{.ibm_location}}",
         {{- end }}
         {{- if .ibm_scope }}
-          ibm_scope="{{ .ibm_scope}}",
+          ibm_scope="{{.ibm_scope}}",
         {{- end }}
         {{- if .ibm_service_instance }}
-          ibm_service_instance="{{ .ibm_service_instance}}",
+          ibm_service_instance="{{.ibm_service_instance}}",
         {{- end }}
         {{- if .ibm_service_name }}
-          ibm_service_name="{{ .ibm_service_name}}",
+          ibm_service_name="{{.ibm_service_name}}",
         {{- end }}
         {{"{{"}}- if .ibm_codeengine_revision_name {{"}}"}}
           ibm_codeengine_revision_name="{{"{{"}}.ibm_codeengine_revision_name{{"}}"}}",
         {{"{{"}}- end {{"}}"}}
-      }[{{"{{"}}.ElapsedTime{{"}}"}}s])) 
+      }[{{"{{"}}.ElapsedTime{{"}}"}}s])) or on() vector(0)
   jqExpression: .data.result.[0].value.[1]


### PR DESCRIPTION
The db task now looks for metrics files based on the `providers` rather than using all files that ends with `.metrics.yaml` in the current directory. 