### PR TITLE
Dockerfile for dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,27 @@
+# Get Iter8
+FROM golang:1.18-buster as builder
+
+# Install wget
+# N/A
+# Set Iter8 version from build args
+# N/A
+
+# Download iter8 compressed binary
+# use COPY instead of wget
+COPY _dist/iter8-linux-amd64.tar.gz iter8-linux-amd64.tar.gz
+
+# Extract iter8
+RUN tar -xvf iter8-linux-amd64.tar.gz
+
+# Extract iter8
+RUN mv linux-amd64/iter8 /bin/iter8
+
+### Multi-stage Docker build
+### New image below
+
+# Small linux image with iter8 binary
+FROM debian:buster-slim
+WORKDIR /
+COPY --from=builder /bin/iter8 /bin/iter8
+# Install curl
+RUN apt-get update && apt-get install -y curl


### PR DESCRIPTION
Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>

Fixes https://github.com/iter8-tools/iter8/issues/1315

To use, first execute `make dist`. Then build image: `docker build . -f Dockerfile.dev -t TAG`