### PR TITLE
Ability to pin the iter8 install action by digest

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,32 +1,45 @@
-name: 'Iter8 Install'
-description: 'Install Iter8 CLI'
+name: "Iter8 Install"
+description: "Install Iter8 CLI"
+branding:
+  icon: check-circle
+  color: green
+
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: Install latest version of Iter8 CLI
+    - name: Install Iter8 CLI
+      shell: bash
       env:
         VERSION: ${{ github.action_ref }}
-      run: | 
+      run: |
         # For details on context variables runner.os and runner.arch, see:
         #    https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
-        # The returned values do not match those used by the build artifacts. 
+        # The returned values do not match those used by the build artifacts.
         # See https://github.com/iter8-tools/iter8/blob/master/Makefile#L4 (and for other valid combinations: https://github.com/mitchellh/gox/blob/master/platform.go#L28-L101)
         # Therefore, this code trasforms the context variables as follows:
         #   os: Linux -> linux, Windows -> windows, macOS -> darwin
         #   arch: X86 -> 386 amd X64 -> amd64
         OS=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]' | sed 's/macos/darwin/')
         ARCH=$(echo ${{ runner.arch }} | sed 's/X86/386/' | sed 's/X64/amd64/')
-        
+
         RELEASE="${{ env.VERSION }}"
         if [ -z $RELEASE ] || [ $RELEASE = "stable" ]; then
-          RELEASE=$(curl --silent "https://api.github.com/repos/iter8-tools/iter8/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-        else
-          RELEASE=$(curl -s "https://api.github.com/repos/iter8-tools/iter8/releases" | jq -r '.[] | .tag_name' | grep $RELEASE | sort -Vr | head -1)
+          REL=$(curl -s "https://api.github.com/repos/iter8-tools/iter8/releases/latest" | jq -r '.tag_name')
         fi
-        echo "Installing Iter8 version $RELEASE"
+        if [ -z $REL ]; then
+         REL=$(curl -s "https://api.github.com/repos/iter8-tools/iter8/tags" | jq --arg RELEASE $RELEASE -r '.[] | select(.commit.sha==$RELEASE) | .name')
+        fi
+        if [ -z $REL ]; then
+          REL=$(curl -s "https://api.github.com/repos/iter8-tools/iter8/releases" | jq -r '.[] | .tag_name' | grep $RELEASE | head -1)
+        fi
+        if [ -z $REL ]; then
+          echo "Invalid release specified: $RELEASE"
+          exit 1
+        fi
+        echo "Installing Iter8 version $REL"
 
         ASSET="iter8-$OS-$ARCH.tar.gz"
-        ASSET_URL="https://github.com/iter8-tools/iter8/releases/download/$RELEASE/$ASSET"
+        ASSET_URL="https://github.com/iter8-tools/iter8/releases/download/$REL/$ASSET"
         echo "Downloading $ASSET_URL"
         wget -q $ASSET_URL && rc=$? || rc=$?
         if [ $rc -eq 0 ]; then
@@ -37,7 +50,3 @@ runs:
           echo "ERROR: unable to download $ASSET from $ASSET_URL"
           exit 1
         fi
-      shell: bash
-branding:
-  icon: check-circle
-  color: green


### PR DESCRIPTION
Tested in a random repository over at: https://github.com/chgl/release-please-test/actions/runs/3587492586/jobs/6037900545
See the changes at https://github.com/chgl/release-please-test/pull/8/files. The second step is expected to fail.

Closes #1376 