### PR TITLE
make dockerfile single stage; add platforms

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -88,6 +88,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_SECRET }}
     - uses: docker/build-push-action@v3
       with:
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
         tags: ${{ env.OWNER }}/iter8:${{ env.VERSION }},${{ env.OWNER }}/iter8:${{ env.MAJOR_MINOR_VERSION }},${{ env.OWNER }}/iter8:latest
         push: true
         build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,20 @@
-# Get Iter8
-FROM golang:1.17-buster as builder
+# Small linux image with iter8 binary
+FROM debian:buster-slim
 
-# Install wget
-RUN apt-get update && apt-get install -y wget
+# Install curl
+RUN apt-get update && apt-get install -y curl
 
 # Set Iter8 version from build args
 ARG TAG
 ENV TAG=${TAG:-v0.13.0}
 
 # Download iter8 compressed binary
-RUN wget https://github.com/iter8-tools/iter8/releases/download/${TAG}/iter8-linux-amd64.tar.gz
+RUN curl -LO https://github.com/iter8-tools/iter8/releases/download/${TAG}/iter8-linux-amd64.tar.gz
 
 # Extract iter8
-RUN tar -xvf iter8-linux-amd64.tar.gz
+RUN tar -xvf iter8-linux-amd64.tar.gz && rm iter8-linux-amd64.tar.gz
 
 # Move iter8
 RUN mv linux-amd64/iter8 /bin/iter8
 
-### Multi-stage Docker build
-### New image below
-
-# Small linux image with iter8 binary
-FROM debian:buster-slim
 WORKDIR /
-COPY --from=builder /bin/iter8 /bin/iter8
-# Install curl
-RUN apt-get update && apt-get install -y curl


### PR DESCRIPTION
We no longer need a multi-stage docker build. This simplifies it.
The image we build does not easily run on Mac M1 architecture. Explicitly identifying a build platform helps.

Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>