### PR TITLE
replace variant with version

### DIFF
--- a/controllers/allcontrollers_test.go
+++ b/controllers/allcontrollers_test.go
@@ -43,7 +43,7 @@ func TestStart(t *testing.T) {
 		Immutable: base.BoolPointer(true),
 		Data: map[string]string{
 			"strSpec": `
-variants:
+versions:
 - resources:
   - gvrShort: deploy
     name: test

--- a/controllers/routemap_test.go
+++ b/controllers/routemap_test.go
@@ -16,18 +16,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// normalizeWeights sets the normalized weights for each variant of the routemap
+// normalizeWeights sets the normalized weights for each version of the routemap
 // the inputs for normalizedWeights include:
-// 1. Whether or not variants are available
+// 1. Whether or not versions are available
 // 2. Weights set using annotations
-// 3. Weights set in the routemap for each variant
-// 4. Default weight of 1 for each variant
+// 3. Weights set in the routemap for each version
+// 4. Default weight of 1 for each version
 func TestNormalizeWeights_sum_zero(t *testing.T) {
-	// 1. Create a routemap with variants
+	// 1. Create a routemap with versions
 	testRoutemap := routemap{
 		mutex:      sync.RWMutex{},
 		ObjectMeta: metav1.ObjectMeta{Name: "testRoutemap", Namespace: "default"},
-		Variants: []variant{
+		Versions: []version{
 			{
 				Resources: []resource{{
 					GVRShort:  "svc",
@@ -67,12 +67,12 @@ func TestNormalizeWeights_sum_zero(t *testing.T) {
 	}
 
 	// 3. For each entry in table driven tests
-	// //	1. Create mock appinformers with variants in different states
+	// //	1. Create mock appinformers with versions in different states
 	// // 2. Get normalize weight
 	var tests = []struct {
 		b []uint32
 	}{
-		{[]uint32{defaultVariantWeight, 0, 0}},
+		{[]uint32{defaultVersionWeight, 0, 0}},
 	}
 
 	for _, e := range tests {
@@ -109,7 +109,7 @@ func TestExtractRouteMap(t *testing.T) {
 		Immutable: base.BoolPointer(true),
 		Data: map[string]string{
 			"strSpec": `
-variants:
+versions:
 - resources: []
   weight: 1
 `,

--- a/controllers/routemaps.go
+++ b/controllers/routemaps.go
@@ -11,7 +11,7 @@ var allRoutemaps = routemaps{
 	nsRoutemap: make(map[string]routemapsByName),
 }
 
-// getRoutemapFromObj extracts a routemap which contains the given object as a variant resource
+// getRoutemapFromObj extracts a routemap which contains the given object as a version resource
 // ToDo: this function assumes that there is at most one routemap that contains a source;
 // a more general idea would be to return a routemap list instead
 func (s *routemaps) getRoutemapFromObj(obj interface{}, gvrShort string) *routemap {
@@ -26,9 +26,9 @@ func (s *routemaps) getRoutemapFromObj(obj interface{}, gvrShort string) *routem
 	// ToDo: speed up this quadruple-nested for loop
 	for _, rmByName := range s.nsRoutemap {
 		for _, rm := range rmByName {
-			for _, v := range rm.Variants {
+			for _, v := range rm.Versions {
 				for _, r := range v.Resources {
-					// go through every resource in every variant in every routemap in every namespace
+					// go through every resource in every version in every routemap in every namespace
 					// check for name match between routemap-resource and unstructured-resource
 					// check for gvrShort match between routemap-resource and unstructured-resource
 					if r.GVRShort == gvrShort && r.Name == u.GetName() {

--- a/controllers/routemaps_test.go
+++ b/controllers/routemaps_test.go
@@ -18,7 +18,7 @@ func TestRouteMaps_Delete(t *testing.T) {
 				"test": {
 					mutex:             sync.RWMutex{},
 					ObjectMeta:        metav1.ObjectMeta{},
-					Variants:          []variant{},
+					Versions:          []version{},
 					RoutingTemplates:  map[string]routingTemplate{},
 					normalizedWeights: []uint32{},
 				},

--- a/testdata/controllers/blue-green-http-kserve/initialize.sh
+++ b/testdata/controllers/blue-green-http-kserve/initialize.sh
@@ -35,7 +35,7 @@ metadata:
     iter8.tools/version: v0.14
 data:
   strSpec: |
-    variants: 
+    versions: 
     - weight: 60
       resources:
       - gvrShort: isvc

--- a/testdata/controllers/canary-http-kserve/initialize.sh
+++ b/testdata/controllers/canary-http-kserve/initialize.sh
@@ -35,7 +35,7 @@ metadata:
     iter8.tools/version: v0.14
 data:
   strSpec: |
-    variants: 
+    versions: 
     - resources:
       - gvrShort: isvc
         name: wisdom-primary

--- a/testdata/controllers/mirror-grpc-kserve/initialize.sh
+++ b/testdata/controllers/mirror-grpc-kserve/initialize.sh
@@ -46,7 +46,7 @@ metadata:
     iter8.tools/version: v0.14
 data:
   strSpec: |
-    variants: 
+    versions: 
     - resources:
       - gvrShort: isvc
         name: wisdom

--- a/testdata/controllers/mirror/default-routing.sh
+++ b/testdata/controllers/mirror/default-routing.sh
@@ -52,8 +52,8 @@ metadata:
     iter8.tools/version: v0.14        
 data:
   strSpec: |
-    variants: 
-    # variant 1 is left unspecified since it does not have a role in routing
+    versions: 
+    # version 1 is left unspecified since it does not have a role in routing
     - 
     - resources:
       - gvrShort: deploy


### PR DESCRIPTION
Replace the term `variant` with `version`. Fixes https://github.com/iter8-tools/iter8/issues/1440.