### PR TITLE
update actions with newer versions

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19
     - uses: actions/checkout@v3
@@ -52,7 +52,7 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
     - name: Update Homebrew formula
-      uses: peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.PERSONAL_TOKEN }}
         repository: iter8-tools/homebrew-iter8
@@ -86,7 +86,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_SECRET }}
-    - uses: docker/build-push-action@v3
+    - uses: docker/build-push-action@v4
       with:
         platforms: linux/amd64,linux/arm64
         tags: ${{ env.OWNER }}/iter8:${{ env.VERSION }},${{ env.OWNER }}/iter8:${{ env.MAJOR_MINOR_VERSION }},${{ env.OWNER }}/iter8:latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19
     - name: Check out code into the Go module directory
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19
     - name: Check out code into the Go module directory
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19
     - name: Check out code into the Go module directory

--- a/controllers/podname_test.go
+++ b/controllers/podname_test.go
@@ -4,25 +4,31 @@ import (
 	"os"
 	"testing"
 
+	util "github.com/iter8-tools/iter8/base"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetPodName(t *testing.T) {
 	var tests = []struct {
-		a string
+		a *string
 		b string
 		c bool
 	}{
-		{"x-0", "x-0", true},
-		{"x-y-0", "x-y-0", true},
-		{"x-1", "x-1", true},
-		{"x-y-1", "x-y-1", true},
-		{"x", "x", true},
-		{"", "", false},
+		{util.StringPointer("x-0"), "x-0", true},
+		{util.StringPointer("x-y-0"), "x-y-0", true},
+		{util.StringPointer("x-1"), "x-1", true},
+		{util.StringPointer("x-y-1"), "x-y-1", true},
+		{util.StringPointer("x"), "x", true},
+		{util.StringPointer(""), "", false},
+		{nil, "", false},
 	}
 
 	for _, e := range tests {
-		_ = os.Setenv(podNameEnvVariable, e.a)
+		if e.a == nil {
+			_ = os.Unsetenv(podNameEnvVariable)
+		} else {
+			_ = os.Setenv(podNameEnvVariable, *e.a)
+		}
 		podName, ok := getPodName()
 		assert.Equal(t, e.b, podName)
 		assert.Equal(t, e.c, ok)


### PR DESCRIPTION
Update actions in workflows with newer versions. 

This change `peter-evans/repository-dispatch@v1` --> `peter-evans/repository-dispatch@v2` fixes https://github.com/iter8-tools/iter8/issues/1444

Other updates were made just to keep current