### PR TITLE
modify templates for readiness

### DIFF
--- a/base/readiness.go
+++ b/base/readiness.go
@@ -138,20 +138,23 @@ func checkObjectExistsAndConditionTrue(t *readinessTask, restCfg *rest.Config) e
 		return nil
 	}
 
+	// set err to nil; will set if there is a problem finding conditions
+	err = nil
+	var cs *string
 	for _, condition := range t.With.Conditions {
 		// otherwise, find the condition and check that it is "True"
 		log.Logger.Trace("looking for condition: ", condition)
 
-		cs, err := getConditionStatus(obj, condition)
+		cs, err = getConditionStatus(obj, condition)
 		if err != nil {
-			return err
+			continue
 		}
 		if strings.EqualFold(*cs, string(corev1.ConditionTrue)) {
 			return nil
 		}
-		return errors.New("condition status not True")
+		err = errors.New("condition status not True")
 	}
-	return nil // no conditions or all were True
+	return err
 }
 
 func gvr(objRef *readinessInputs) schema.GroupVersionResource {

--- a/base/readiness_test.go
+++ b/base/readiness_test.go
@@ -173,7 +173,7 @@ func (t *readinessTaskBuilder) withTimeout(timeout string) *readinessTaskBuilder
 }
 
 func (t *readinessTaskBuilder) withCondition(condition string) *readinessTaskBuilder {
-	t.With.Condition = &condition
+	t.With.Conditions = append(t.With.Conditions, condition)
 	return t
 }
 

--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: controller
-version: 0.1.12
+version: 0.17.0
 description: Iter8 controller controller
 type: application
 keywords:

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -16,6 +16,10 @@ resourceTypes:
     Group: ""
     Version: v1
     Resource: services
+  service:
+    Group: ""
+    Version: v1
+    Resource: services
   cm:
     Group: ""
     Version: v1
@@ -25,15 +29,13 @@ resourceTypes:
     Version: v1
     Resource: deployments
     conditions:
-    - name: Available
-      status: "True"
+    - Available
   isvc:
     Group: serving.kserve.io
     Version: v1beta1
     Resource: inferenceservices
     conditions:
-    - name: Ready
-      status: "True"
+    - Ready
   vs:
     Group: networking.istio.io
     Version: v1beta1

--- a/charts/iter8/Chart.yaml
+++ b/charts/iter8/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: iter8
-version: 0.17.0
+version: 0.17.1
 description: Iter8 experiment chart
 type: application
 home: https://iter8.tools

--- a/charts/iter8/values.yaml
+++ b/charts/iter8/values.yaml
@@ -23,6 +23,10 @@ resourceTypes:
     Group: ""
     Version: v1
     Resource: services
+  service:
+    Group: ""
+    Version: v1
+    Resource: services
   cm:
     Group: ""
     Version: v1
@@ -32,15 +36,13 @@ resourceTypes:
     Version: v1
     Resource: deployments
     conditions:
-    - name: Available
-      status: "True"
+    - Available
   isvc:
     Group: serving.kserve.io
     Version: v1beta1
     Resource: inferenceservices
     conditions:
-    - name: Ready
-      status: "True"
+    - Ready
   vs:
     Group: networking.istio.io
     Version: v1beta1

--- a/charts/iter8/values.yaml
+++ b/charts/iter8/values.yaml
@@ -17,3 +17,31 @@ resources:
 
 ### metricsServerURL is the URL to the Metrics server 
 metricsServerURL: http://iter8.default:8080
+
+resourceTypes:
+  svc:
+    Group: ""
+    Version: v1
+    Resource: services
+  cm:
+    Group: ""
+    Version: v1
+    Resource: configmaps
+  deploy:
+    Group: apps
+    Version: v1
+    Resource: deployments
+    conditions:
+    - name: Available
+      status: "True"
+  isvc:
+    Group: serving.kserve.io
+    Version: v1beta1
+    Resource: inferenceservices
+    conditions:
+    - name: Ready
+      status: "True"
+  vs:
+    Group: networking.istio.io
+    Version: v1beta1
+    Resource: virtualservices

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -13,15 +13,7 @@ const (
 // GroupVersionResourceConditions is a Kubernetes resource type along with a list of conditions
 type GroupVersionResourceConditions struct {
 	schema.GroupVersionResource
-	Conditions []Condition `json:"conditions,omitempty"`
-}
-
-// Condition is the condition within resource status
-type Condition struct {
-	// Name of the condition
-	Name string `json:"name"`
-	// Status of the condition
-	Status string `json:"status"`
+	Conditions []string `json:"conditions,omitempty"`
 }
 
 // Config defines the configuration of the controllers

--- a/controllers/config_test.go
+++ b/controllers/config_test.go
@@ -39,10 +39,9 @@ func TestReadConfig(t *testing.T) {
 					Version:  "v1beta1",
 					Resource: "inferenceservices",
 				},
-				Conditions: []Condition{{
-					Name:   "Ready",
-					Status: "True",
-				}},
+				Conditions: []string{
+					"Ready",
+				},
 			})
 		} else {
 			assert.Error(t, err)

--- a/controllers/routemap.go
+++ b/controllers/routemap.go
@@ -421,7 +421,7 @@ func conditionsSatisfied(u *unstructured.Unstructured, gvrShort string, config *
 				return false
 			}
 			name, found, err := unstructured.NestedString(condition, "type")
-			if !found || err != nil || !strings.EqualFold(name, c.Name) {
+			if !found || err != nil || !strings.EqualFold(name, c) {
 				log.Logger.Trace("condition with no type")
 				continue
 			}
@@ -443,7 +443,7 @@ func conditionsSatisfied(u *unstructured.Unstructured, gvrShort string, config *
 			}
 
 			// check if condition status equals the required value specified in config
-			if !strings.EqualFold(status, c.Status) {
+			if !strings.EqualFold(status, "True") {
 				log.Logger.Info("condition not satisfied")
 				return false
 			}

--- a/controllers/routemap_test.go
+++ b/controllers/routemap_test.go
@@ -132,10 +132,9 @@ func TestConditionsSatisfied(t *testing.T) {
 	u.SetGeneration(13)
 	config := &Config{
 		ResourceTypes: map[string]GroupVersionResourceConditions{"foo": {
-			Conditions: []Condition{{
-				Name:   "bar",
-				Status: "True",
-			}},
+			Conditions: []string{
+				"bar",
+			},
 		}},
 	}
 	var gen12 = int64(12)

--- a/testdata/controllers/config.yaml
+++ b/testdata/controllers/config.yaml
@@ -19,8 +19,7 @@ resourceTypes:
     Version: v1beta1
     Resource: inferenceservices
     conditions:
-    - name: Ready
-      status: "True"
+    - Ready
   vs:
     Group: networking.istio.io
     Version: v1beta1


### PR DESCRIPTION
Redefine iter8 readiness templates using a map `resourceTypes` similar to that in the controller chart.